### PR TITLE
Refactoring MaterialX implementation to align more closely with the spec

### DIFF
--- a/reference/open_pbr_surface.mtlx
+++ b/reference/open_pbr_surface.mtlx
@@ -376,7 +376,7 @@
       <input name="base" type="BSDF" nodename="coat_substrate_attenuated" />
     </layer>
 
-  <!-- Fuzz Layer -->
+    <!-- Fuzz Layer -->
     <!-- TODO: Add a new BSDF node for the selected fuzz model in OpenPBR -->
     <sheen_bsdf name="fuzz_bsdf" type="BSDF">
       <input name="weight" type="float" interfacename="fuzz_weight" />


### PR DESCRIPTION
Here is an attempt to write the MaterialX implementation in a way which aligns as closely as possible, given the current form of the MaterialX spec, with the formalism in the current OpenPBR spec. To make it easier to digest (since XML is tough to read), I wrote the functional form of it in Latex as screen-shotted below.

The changes i've made roughly amount to:

- making the layers align with the OpenPBR spec, both the structure and the naming conventions.

- adding the thin-walled subsurface model, as close as I can get it.

- fixing up all the parameter names to align.

<br>
This still differs in various important respects to the spec:

- the way the coat absorption is implemented is something of a hack (and actually does not exactly correspond to what is done in either standard surface or OpenPBR). Doing it properly requires a deeper discussion about how to account for the medium of a dielectric layer in MaterialX (so beyond the scope of this PR). At least the way it is done is no worse than what was done for the MaterialX standard surface implementation.
  
- there is no way to specify how the `subsurface_bsdf` parameters are mapped into the volumetric medium coefficients, so our "similarity-theory" based mapping is not expressible.

- there is no way to implement the volumetric medium of the "translucent base" (`transmission_depth` etc.), as the dielectric BSDF in MaterialX does not have the concept of the "interior medium". Similarly for the dispersion properties (`transmission_dispersion_abbe_number` etc.). This can maybe be done with the "VDF" construct, but it's unclear how to do it.
    
- there is no facility for the (very useful) "thin-walled glass" model (e.g. see slide 34 of ["Revisiting Physically Based Shading at Imageworks"](https://blog.selfshadow.com/publications/s2017-shading-course/imageworks/s2017_pb) 2017). This is implemented in Arnold for example (`MicrofacetThinRefractionBSDF`), but not in the standard surface spec (hence it did not get into MaterialX either I assume).

- For the thin-walled SSS model, ideally there would be a R/T mode for the Oren-Nayar BSDF, which would make more sense than the ad-hoc `translucent_bsdf` I think. (NB, in the MaterialX spec, the only way to know that `translucent_bsdf` refers to a diffuse lobe oriented into the transmission hemisphere, is by guessing based on the names. That's not ideal).

- I did not attempt to implement in nodes the formulas for `specular_ior_level` / `coat_ior_level` yet. This should be fairly easily doable though. (Can be done in a separate PR).

- Unlike MaterialX, thin-film is not represented as a separate layer/BSDF in OpenPBR (or standard surface), it just modifies the microfacet BSDF of the base metal/dielectric. It seems reasonable to model it as a layer though. Technically the IOR of the thin-film should alter the Fresnel of the underlying layer (and in turn the thin-film effect should depend on the IOR of the layer above it), as noted e.g. in https://github.com/AcademySoftwareFoundation/OpenPBR/issues/79. This would be a bit more clear if the thin-film was an explicit layer (though whether we attempt to explain how to account for the adjacent IORs, I'm not sure). I would be open to modifying the OpenPBR spec, to align with MaterialX, in this instance.

- There is no "specular layer" in OpenPBR, as physically this is just the interface of the base dielectric. In MaterialX, I take it that `layer(specular_bsdf, specular_btdf)` is just a convenient shorthand for approximating a dielectric BSDF via albedo scaling (of the BRDF "on top" of the BTDF), even though there's not actually any layering happening (except in the sense that there's an upper and lower hemisphere..). I find this ugly, but obviously we have to work with it.

- It's not very clear how the albedo scaling for the fuzz layer works in MaterialX. It could also be clearer in OpenPBR (as requested in https://github.com/AcademySoftwareFoundation/OpenPBR/issues/84), but we do try to make it explicit that `fuzz_color` does not tint the base, whereas this is unstated in MaterialX.

- the emission model uses `generalized_schlick_edf` with `color90 = coat_ior_to_F0`. I'm not sure what this is trying to model, but it doesn't (so far) appear in the OpenPBR spec. We could augment the spec perhaps if this is something worth having.

- the `coat_affect` parameters and their (rather ad-hoc) effect taken from the standard surface spec, is coded up in the graph -- but at this moment not mentioned in the OpenPBR spec. We may wish to leave this in (the spec needs to be updated if we want to keep them), or try to improve the formulas, not sure.



![image](https://github.com/AcademySoftwareFoundation/OpenPBR/assets/2774364/ca61a651-1933-4c3a-81d4-a12e1577b80d)

![image](https://github.com/AcademySoftwareFoundation/OpenPBR/assets/2774364/b3e2407a-b53a-48b9-b986-f457aa37b9d0)

![image](https://github.com/AcademySoftwareFoundation/OpenPBR/assets/2774364/91e71637-6dcb-4313-9835-ce53b3cbaf99)

