### PR TITLE
Fix attenuation of coated emission in MaterialX

### DIFF
--- a/reference/open_pbr_surface.mtlx
+++ b/reference/open_pbr_surface.mtlx
@@ -378,9 +378,13 @@
       <input name="in1" type="EDF" nodename="emission_edf" />
       <input name="in2" type="color3" interfacename="coat_color" />
     </multiply>
+    <subtract name="one_minus_coat_F0" type="float">
+      <input name="in1" type="float" value="1.0" />
+      <input name="in2" type="float" nodename="coat_ior_to_F0" />
+    </subtract>
     <generalized_schlick_edf name="coat_emission_edf" type="EDF">
-      <input name="color0" type="color3" value="1.0, 1.0, 1.0" />
-      <input name="color90" type="color3" nodename="coat_ior_to_F0" channels="rrr" />
+      <input name="color0" type="color3" nodename="one_minus_coat_F0" channels="rrr" />
+      <input name="color90" type="color3" value="0.0, 0.0, 0.0" />
       <input name="exponent" type="float" value="5.0" />
       <input name="base" type="EDF" nodename="coat_tinted_emission_edf" />
     </generalized_schlick_edf>


### PR DESCRIPTION
As discussed on Slack [here](https://academysoftwarefdn.slack.com/archives/C055KD5SY2Y/p1694703184913529).