### PR TITLE
Improve framing of reference implementation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1288,7 +1288,7 @@ MaterialX reference implementation
 
 We provide a [reference implementation](reference/open_pbr_surface.mtlx) in MaterialX, which is based on the derivation in the previous section and the implementation of Autodesk Standard Surface [#Georgiev2019].
 
-!!! ERROR: This implementation is a work-in-progress.
+!!! WARNING
          Our MaterialX implementation is as faithful to the OpenPBR specification as existing shading languages (e.g. OSL, MDL) support.
          Thus it is still missing certain features, i.e.:
             - the microfacet NDF anisotropy formula of the Microfacet model section


### PR DESCRIPTION
- Remove the phrase "work-in-progress", as the accuracy of our reference implementation is primarily gated by the evolution of industry shading models.
- Use our standard yellow warning box, not a red error box.