### PR TITLE
Add space under front-page caption

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 <img src="images/OpenPBR title.jpg" title="OpenPBR demonstration scene" />
 <sub><i>Shader Playground, rendered in Arnold for Maya, using OpenPBR Surface. Artwork by Nikie Monteleone.</i></sub>
 </p>
+<br>
 
 A white paper specifying an über-shader that aims to provide a material representation capable of accurately modeling the vast majority of materials used in practical visual effects and feature animation productions.
 


### PR DESCRIPTION
Adds a space under the image/caption, which helps to visually separate the caption from the paragraph.

Old:

![image](https://github.com/AcademySoftwareFoundation/OpenPBR/assets/2774364/90b56a6a-0e77-40d6-b151-75ac3f891fad)


New:

![image](https://github.com/AcademySoftwareFoundation/OpenPBR/assets/2774364/9f5973b7-12ad-41c5-824b-e1f2198586fd)
