### PR TITLE
Remove Standard Surface approximation of coat darkening

### DIFF
--- a/reference/open_pbr_surface.mtlx
+++ b/reference/open_pbr_surface.mtlx
@@ -168,39 +168,14 @@
       <input name="in2" type="vector3" interfacename="geometry_tangent" />
     </ifgreater>
 
-    <!-- Colors influenced by coat ("coat gamma") -->
-    <clamp name="coat_clamped" type="float">
-      <input name="in" type="float" interfacename="coat_weight" />
-    </clamp>
-    <multiply name="coat_gamma_multiply" type="float">
-      <input name="in1" type="float" nodename="coat_clamped" />
-      <input name="in2" type="float" value="1.0" />
-    </multiply>
-    <add name="coat_gamma" type="float">
-      <input name="in1" type="float" nodename="coat_gamma_multiply" />
-      <input name="in2" type="float" value="1.0" />
-    </add>
-    <max name="base_color_nonnegative" type="color3">
-      <input name="in1" type="color3" interfacename="base_color" />
-      <input name="in2" type="float" value="0.0" />
-    </max>
-    <power name="coat_affected_diffuse_color" type="color3">
-      <input name="in1" type="color3" nodename="base_color_nonnegative" />
-      <input name="in2" type="float" nodename="coat_gamma" />
-    </power>
+    <!-- Subsurface (thin-walled) -->
     <max name="subsurface_color_nonnegative" type="color3">
       <input name="in1" type="color3" interfacename="subsurface_color" />
       <input name="in2" type="float" value="0.0" />
     </max>
-    <power name="coat_affected_subsurface_color" type="color3">
-      <input name="in1" type="color3" nodename="subsurface_color_nonnegative" />
-      <input name="in2" type="float" nodename="coat_gamma" />
-    </power>
-
-    <!-- Subsurface (thin-walled) -->
     <oren_nayar_diffuse_bsdf name="subsurface_thin_walled_reflection_bsdf" type="BSDF">
       <input name="weight" type="float" value="1.0" />
-      <input name="color" type="color3" nodename="coat_affected_subsurface_color" />
+      <input name="color" type="color3" nodename="subsurface_color_nonnegative" />
       <input name="roughness" type="float" interfacename="base_roughness" />
       <input name="normal" type="vector3" interfacename="geometry_normal" />
     </oren_nayar_diffuse_bsdf>
@@ -218,7 +193,7 @@
     </multiply>
     <translucent_bsdf name="subsurface_thin_walled_transmission_bsdf" type="BSDF">
       <input name="weight" type="float" value="1.0" />
-      <input name="color" type="color3" nodename="coat_affected_subsurface_color" />
+      <input name="color" type="color3" nodename="subsurface_color_nonnegative" />
       <input name="normal" type="vector3" interfacename="geometry_normal" />
     </translucent_bsdf>
     <add name="one_plus_subsurface_anisotropy" type="float">
@@ -249,16 +224,20 @@
     </multiply>
     <subsurface_bsdf name="subsurface_bsdf" type="BSDF">
       <input name="weight" type="float" value="1.0" />
-      <input name="color" type="color3" nodename="coat_affected_subsurface_color" />
+      <input name="color" type="color3" nodename="subsurface_color_nonnegative" />
       <input name="radius" type="vector3" nodename="subsurface_radius_scaled" />
       <input name="anisotropy" type="float" interfacename="subsurface_anisotropy" />
       <input name="normal" type="vector3" interfacename="geometry_normal" />
     </subsurface_bsdf>
 
     <!-- Opaque Dielectric Base -->
+    <max name="base_color_nonnegative" type="color3">
+      <input name="in1" type="color3" interfacename="base_color" />
+      <input name="in2" type="float" value="0.0" />
+    </max>
     <oren_nayar_diffuse_bsdf name="diffuse_bsdf" type="BSDF">
       <input name="weight" type="float" interfacename="base_weight" />
-      <input name="color" type="color3" nodename="coat_affected_diffuse_color" />
+      <input name="color" type="color3" nodename="base_color_nonnegative" />
       <input name="roughness" type="float" interfacename="base_roughness" />
       <input name="normal" type="vector3" interfacename="geometry_normal" />
     </oren_nayar_diffuse_bsdf>


### PR DESCRIPTION
This changelist removes the legacy Standard Surface approximation of the darkening and saturation of base colors under coatings.

In a future version of OpenPBR, our plan is to implement this coat darkening in a more subtle, physically based fashion, but the current approximation is too far from this ground truth to be useful.