### PR TITLE
Adding example materials

### DIFF
--- a/examples/open_pbr_aluminum_brushed.mtlx
+++ b/examples/open_pbr_aluminum_brushed.mtlx
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<materialx version="1.38" colorspace="lin_rec709">
+  <surfacematerial name="Aluminum_Brushed" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="open_pbr_surface_surfaceshader" />
+  </surfacematerial>
+  <open_pbr_surface name="open_pbr_surface_surfaceshader" type="surfaceshader">
+    <input name="base_color" type="color3" value="0.912, 0.914, 0.920" />
+    <input name="base_metalness" type="float" value="1.0" />
+    <input name="specular_color" type="color3" value="0.970, 0.979, 0.988" />
+    <input name="specular_roughness" type="float" value="0.2" />
+    <input name="specular_anisotropy" type="float" value="0.9" />
+    <input name="specular_rotation" type="float" value="0.25" />
+  </open_pbr_surface>
+</materialx>

--- a/examples/open_pbr_carpaint.mtlx
+++ b/examples/open_pbr_carpaint.mtlx
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<materialx version="1.38" colorspace="lin_rec709">
+  <surfacematerial name="Car_Paint" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="open_pbr_surface_surfaceshader" />
+  </surfacematerial>
+  <open_pbr_surface name="open_pbr_surface_surfaceshader" type="surfaceshader">
+    <input name="base_color" type="color3" value="0.1, 0.6, 0.9" />
+    <input name="specular_ior" type="float" value="1.6" />
+    <input name="specular_roughness" type="float" value="0.3" />
+    <input name="coat_weight" type="float" value="1" />
+    <input name="coat_roughness" type="float" value="0.02" />
+    <input name="coat_ior" type="float" value="1.6" />
+  </open_pbr_surface>
+</materialx>

--- a/examples/open_pbr_glass.mtlx
+++ b/examples/open_pbr_glass.mtlx
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<materialx version="1.38" colorspace="lin_rec709">
+  <surfacematerial name="Glass" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="open_pbr_surface_surfaceshader" />
+  </surfacematerial>
+  <open_pbr_surface name="open_pbr_surface_surfaceshader" type="surfaceshader">
+    <input name="specular_roughness" type="float" value="0.0" />
+    <input name="specular_ior" type="float" value="1.52" />
+    <input name="transmission_weight" type="float" value="1.0" />
+    <input name="transmission_dispersion_abbe_number" type="float" value="64" />
+    <input name="transmission_dispersion_scale" type="float" value="1.0" />
+  </open_pbr_surface>
+</materialx>

--- a/examples/open_pbr_honey.mtlx
+++ b/examples/open_pbr_honey.mtlx
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<materialx version="1.38" colorspace="lin_rec709">
+  <surfacematerial name="Honey" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="open_pbr_surface_surfaceshader" />
+  </surfacematerial>
+  <open_pbr_surface name="open_pbr_surface_surfaceshader" type="surfaceshader">
+    <input name="specular_roughness" type="float" value="0.0" />
+    <input name="specular_ior" type="float" value="1.504" />
+    <input name="transmission_weight" type="float" value="1.0" />
+    <input name="transmission_color" type="color3" value="0.83, 0.4, 0.04" />
+    <input name="transmission_depth" type="float" value="2" />
+    <input name="transmission_scatter" type="color3" value="0.9, 0.9, 0.9" />
+  </open_pbr_surface>
+</materialx>

--- a/examples/open_pbr_ketchup.mtlx
+++ b/examples/open_pbr_ketchup.mtlx
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<materialx version="1.38" colorspace="lin_rec709">
+  <surfacematerial name="Ketchup" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="open_pbr_surface_surfaceshader" />
+  </surfacematerial>
+  <open_pbr_surface name="open_pbr_surface_surfaceshader" type="surfaceshader">
+    <input name="base_color" type="color3" value="0.164, 0.006, 0.002" />
+    <input name="specular_roughness" type="float" value="0" />
+    <input name="specular_ior" type="float" value="1.3" />
+    <input name="subsurface_weight" type="float" value="1.0" />
+    <input name="subsurface_color" type="color3" value="0.164, 0.006, 0.002" />
+    <input name="subsurface_radius_scale" type="color3" value="0.476, 0.058, 0.039" />
+  </open_pbr_surface>
+</materialx>

--- a/examples/open_pbr_lightbulb.mtlx
+++ b/examples/open_pbr_lightbulb.mtlx
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<materialx version="1.38" colorspace="lin_rec709">
+  <surfacematerial name="Light_Bulb" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="open_pbr_surface_surfaceshader" />
+  </surfacematerial>
+  <open_pbr_surface name="open_pbr_surface_surfaceshader" type="surfaceshader">
+    <input name="emission_color" type="color3" value="1.000, 0.415, 0.099" />
+    <input name="emission_luminance" type="float" value="10000" />
+  </open_pbr_surface>
+</materialx>

--- a/examples/open_pbr_pearl.mtlx
+++ b/examples/open_pbr_pearl.mtlx
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<materialx version="1.38" colorspace="lin_rec709">
+  <surfacematerial name="Pearl" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="open_pbr_surface_surfaceshader" />
+  </surfacematerial>
+  <open_pbr_surface name="open_pbr_surface_surfaceshader" type="surfaceshader">
+    <input name="base_color" type="color3" value="0.8, 0.75, 0.7" />
+    <input name="specular_roughness" type="float" value="0.35" />
+    <input name="specular_ior" type="float" value="1.5" />
+    <input name="subsurface_weight" type="float" value="1.0" />
+    <input name="subsurface_color" type="color3" value="0.8, 0.75, 0.7" />
+    <input name="subsurface_radius_scale" type="color3" value="0.3, 0.5, 0.3" />
+    <input name="coat_weight" type="float" value="1" />
+    <input name="coat_roughness" type="float" value="0.15" />
+    <input name="coat_ior" type="float" value="1.68" />
+    <input name="thin_film_thickness" type="float" value="420" />
+    <input name="thin_film_ior" type="float" value="2" />
+  </open_pbr_surface>
+</materialx>

--- a/examples/open_pbr_soapbubble.mtlx
+++ b/examples/open_pbr_soapbubble.mtlx
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<materialx version="1.38" colorspace="lin_rec709">
+  <surfacematerial name="Soap_Bubble" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="open_pbr_surface_surfaceshader" />
+  </surfacematerial>
+  <open_pbr_surface name="open_pbr_surface_surfaceshader" type="surfaceshader">
+    <input name="specular_roughness" type="float" value="0" />
+    <input name="specular_ior" type="float" value="1.0" />
+    <input name="transmission_weight" type="float" value="1.0" />
+    <input name="thin_film_thickness" type="float" value="500" />
+    <input name="thin_film_ior" type="float" value="1.4" />
+    <input name="geometry_thin_walled" type="boolean" value="true" />
+  </open_pbr_surface>
+</materialx>

--- a/examples/open_pbr_surface_default.mtlx
+++ b/examples/open_pbr_surface_default.mtlx
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<materialx version="1.38" colorspace="lin_rec709">
+  <surfacematerial name="Default" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="open_pbr_surface_surfaceshader" />
+    <input name="displacementshader" type="displacementshader" value="" />
+  </surfacematerial>
+  <open_pbr_surface name="open_pbr_surface_surfaceshader" type="surfaceshader">
+    <input name="base_weight" type="float" value="1.0" />
+    <input name="base_color" type="color3" value="0.8, 0.8, 0.8" />
+    <input name="base_roughness" type="float" value="0.0" />
+    <input name="base_metalness" type="float" value="0.0" />
+    <input name="specular_weight" type="float" value="1.0" />
+    <input name="specular_color" type="color3" value="1, 1, 1" />
+    <input name="specular_roughness" type="float" value="0.3" />
+    <input name="specular_ior" type="float" value="1.5" />
+    <input name="specular_ior_level" type="float" value="0.5" />
+    <input name="specular_anisotropy" type="float" value="0.0" />
+    <input name="specular_rotation" type="float" value="0.0" />
+    <input name="transmission_weight" type="float" value="0.0" />
+    <input name="transmission_color" type="color3" value="1, 1, 1" />
+    <input name="transmission_depth" type="float" value="0.0" />
+    <input name="transmission_scatter" type="color3" value="0, 0, 0" />
+    <input name="transmission_scatter_anisotropy" type="float" value="0.0" />
+    <input name="transmission_dispersion" type="float" value="0.0" />
+    <input name="subsurface_weight" type="float" value="0" />
+    <input name="subsurface_color" type="color3" value="0.8, 0.8, 0.8" />
+    <input name="subsurface_radius" type="float" value="1.0" />
+    <input name="subsurface_radius_scale" type="color3" value="1.0, 0.5, 0.25" />
+    <input name="subsurface_anisotropy" type="float" value="0.0" />
+    <input name="fuzz_weight" type="float" value="0.0" />
+    <input name="fuzz_color" type="color3" value="1, 1, 1" />
+    <input name="fuzz_roughness" type="float" value="0.5" />
+    <input name="coat_weight" type="float" value="0.0" />
+    <input name="coat_color" type="color3" value="1, 1, 1" />
+    <input name="coat_roughness" type="float" value="0.0" />
+    <input name="coat_anisotropy" type="float" value="0.0" />
+    <input name="coat_rotation" type="float" value="0.0" />
+    <input name="coat_ior" type="float" value="1.6" />
+    <input name="coat_ior_level" type="float" value="0.5" />
+    <input name="thin_film_thickness" type="float" value="0" />
+    <input name="thin_film_ior" type="float" value="1.5" />
+    <input name="emission_luminance" type="float" value="0.0" />
+    <input name="emission_color" type="color3" value="1, 1, 1" />
+    <input name="geometry_opacity" type="color3" value="1, 1, 1" />
+    <input name="geometry_thin_walled" type="boolean" value="false" />
+  </open_pbr_surface>
+</materialx>

--- a/examples/open_pbr_velvet.mtlx
+++ b/examples/open_pbr_velvet.mtlx
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<materialx version="1.38" colorspace="lin_rec709">
+  <surfacematerial name="Velvet" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="open_pbr_surface_surfaceshader" />
+  </surfacematerial>
+  <open_pbr_surface name="open_pbr_surface_surfaceshader" type="surfaceshader">
+    <input name="base_color" type="color3" value="0.02, 0.02, 0.02" />
+    <input name="specular_roughness" type="float" value="0.8" />
+    <input name="fuzz_weight" type="float" value="1" />
+    <input name="fuzz_color" type="color3" value="0.4, 0.4, 0.4" />
+    <input name="fuzz_roughness" type="float" value="0.2" />
+  </open_pbr_surface>
+</materialx>


### PR DESCRIPTION
Here's a collection of example materials, in .mtlx format, that cover most of the parameters found in the OpenPBR specification, as suggested in this Slack thread: https://academysoftwarefdn.slack.com/archives/C06365EAQMP/p1698709666974279

- Any parameters that would’ve been the same as the default have been omitted, to keep the files as minimal as possible, with potential loss of clarity in some cases. Let me know if there are any concerns with this.
- Scene unit for the test renders was set to centimeters. This brings up something I find a bit confusing, why the Subsurface Radius unit isn’t specified in the mtlx file, when the goal is to unify material parameters across applications? Subsurface materials will look different depending on the users scene units. Why is the unit not specified, as it is with Thin Film Thickness, and Emission Luminance?
- Tests were rendered using aiOpenPBRSurface in Arnold 7.2.5.0 Beta 60, kindly provided by @portsmouth 
- `transmission_dispersion_abbe_number` and `transmission_dispersion_scale` from the white paper are not yet in the reference implementation. Do we want to wait with them for the Glass material, or should I keep them, for future compatibility? They are functional in Arnold at least.
- For the above reason, all materials except Glass are confirmed working in MaterialX Viewer, using the OpenPBR reference implementation.
- I added the default material as well. Let me know if it doesn't belong here.
- All materials are thoroughly researched to be as physically accurate as possible

### Brushed Aluminum
```
<input name="base_color" type="color3" value="0.912, 0.914, 0.920" />
<input name="base_metalness" type="float" value="1.0" />
<input name="specular_color" type="color3" value="0.970, 0.979, 0.988" />
<input name="specular_roughness" type="float" value="0.2" />
<input name="specular_anisotropy" type="float" value="0.9" />
<input name="specular_rotation" type="float" value="0.25" />
```
![Aluminum Brushed OpenPBR Caustics](https://github.com/AcademySoftwareFoundation/OpenPBR/assets/13031779/916664d5-dac3-4317-8180-96777fd01a48)
### Car Paint
```
<input name="base_color" type="color3" value="0.1, 0.6, 0.9" />
<input name="specular_ior" type="float" value="1.6" />
<input name="specular_roughness" type="float" value="0.3" />
<input name="coat_weight" type="float" value="1" />
<input name="coat_roughness" type="float" value="0.02" />
<input name="coat_ior" type="float" value="1.6" />
```
![Car Paint OpenPBR Caustics](https://github.com/AcademySoftwareFoundation/OpenPBR/assets/13031779/f1b2a126-75fd-428e-b72a-cb53029ac8db)
### Glass
```
<input name="specular_roughness" type="float" value="0.0" />
<input name="specular_ior" type="float" value="1.52" />
<input name="transmission_weight" type="float" value="1.0" />
<input name="transmission_dispersion_abbe_number" type="float" value="64" />
<input name="transmission_dispersion_scale" type="float" value="1.0" />
```
![Glass OpenPBR Caustics](https://github.com/AcademySoftwareFoundation/OpenPBR/assets/13031779/003de711-72ba-4a48-9eab-c1d396e87584)
### Honey
```
<input name="specular_roughness" type="float" value="0.0" />
<input name="specular_ior" type="float" value="1.504" />
<input name="transmission_weight" type="float" value="1.0" />
<input name="transmission_color" type="color3" value="0.83, 0.4, 0.04" />
<input name="transmission_depth" type="float" value="2" />
<input name="transmission_scatter" type="color3" value="0.9, 0.9, 0.9" />
```
![Honey OpenPBR](https://github.com/AcademySoftwareFoundation/OpenPBR/assets/13031779/62a43403-3c0e-4046-89e1-5fa440adb0cd)
### Ketchup
```
<input name="base_color" type="color3" value="0.164, 0.006, 0.002" />
<input name="specular_roughness" type="float" value="0" />
<input name="specular_ior" type="float" value="1.3" />
<input name="subsurface_weight" type="float" value="1.0" />
<input name="subsurface_color" type="color3" value="0.164, 0.006, 0.002" />
<input name="subsurface_radius_scale" type="color3" value="0.476, 0.058, 0.039" />
```
![Ketchup OpenPBR](https://github.com/AcademySoftwareFoundation/OpenPBR/assets/13031779/aac1aacb-b9e4-466a-9469-7c8511d83935)
### Light Bulb
```
<input name="emission_color" type="color3" value="1.000, 0.415, 0.099" />
<input name="emission_luminance" type="float" value="10000" />
```
![Light Bulb OpenPBR2](https://github.com/AcademySoftwareFoundation/OpenPBR/assets/13031779/2d5df6f2-2530-492e-afea-8f5becc7e3d2)
### Pearl
```
<input name="base_color" type="color3" value="0.8, 0.75, 0.7" />
<input name="specular_roughness" type="float" value="0.35" />
<input name="specular_ior" type="float" value="1.5" />
<input name="subsurface_weight" type="float" value="1.0" />
<input name="subsurface_color" type="color3" value="0.8, 0.75, 0.7" />
<input name="subsurface_radius_scale" type="color3" value="0.3, 0.5, 0.3" />
<input name="coat_weight" type="float" value="1" />
<input name="coat_roughness" type="float" value="0.15" />
<input name="coat_ior" type="float" value="1.68" />
<input name="thin_film_thickness" type="float" value="420" />
<input name="thin_film_ior" type="float" value="2" />
```
![Pearl OpenPBR Caustics](https://github.com/AcademySoftwareFoundation/OpenPBR/assets/13031779/58dd1e67-d86c-4b2f-88c4-bc6814f5ddea)
### Soap Bubble
```
<input name="specular_roughness" type="float" value="0" />
<input name="specular_ior" type="float" value="1.0" />
<input name="transmission_weight" type="float" value="1.0" />
<input name="thin_film_thickness" type="float" value="500" />
<input name="thin_film_ior" type="float" value="1.4" />
<input name="geometry_thin_walled" type="boolean" value="true" />
```
![Soap Bubble OpenPBR Thin Walled](https://github.com/AcademySoftwareFoundation/OpenPBR/assets/13031779/1d30e247-9088-4285-8c5f-12b3eadf31c7)
### Velvet
```
<input name="base_color" type="color3" value="0.02, 0.02, 0.02" />
<input name="specular_roughness" type="float" value="0.8" />
<input name="fuzz_weight" type="float" value="1" />
<input name="fuzz_color" type="color3" value="0.4, 0.4, 0.4" />
<input name="fuzz_roughness" type="float" value="0.2" />
```
![Velvet OpenPBR](https://github.com/AcademySoftwareFoundation/OpenPBR/assets/13031779/0b7f8c4e-7a7f-4e02-90c9-d0aa655817bb)
