### PR TITLE
Update anisotropy in reference graph

### DIFF
--- a/reference/open_pbr_surface.mtlx
+++ b/reference/open_pbr_surface.mtlx
@@ -110,10 +110,10 @@
       <input name="bg" type="float" interfacename="specular_roughness" />
       <input name="mix" type="float" nodename="coat_affect_roughness_multiply2" />
     </mix>
-    <roughness_anisotropy name="main_roughness" type="vector2">
+    <open_pbr_anisotropy name="main_roughness" type="vector2">
       <input name="roughness" type="float" nodename="coat_affected_roughness" />
       <input name="anisotropy" type="float" interfacename="specular_anisotropy" />
-    </roughness_anisotropy>
+    </open_pbr_anisotropy>
     <!-- Calculate transmission roughness -->
     <clamp name="transmission_roughness_clamped" type="float">
       <input name="in" type="float" interfacename="specular_roughness" />
@@ -123,10 +123,10 @@
       <input name="bg" type="float" nodename="transmission_roughness_clamped" />
       <input name="mix" type="float" nodename="coat_affect_roughness_multiply2" />
     </mix>
-    <roughness_anisotropy name="transmission_roughness" type="vector2">
+    <open_pbr_anisotropy name="transmission_roughness" type="vector2">
       <input name="roughness" type="float" nodename="coat_affected_transmission_roughness" />
       <input name="anisotropy" type="float" interfacename="specular_anisotropy" />
-    </roughness_anisotropy>
+    </open_pbr_anisotropy>
 
     <!-- Tangent rotation -->
     <multiply name="tangent_rotate_degree" type="float">
@@ -435,10 +435,10 @@
       <input name="in1" type="BSDF" nodename="thin_film_layer" />
       <input name="in2" type="color3" nodename="coat_attenuation" />
     </multiply>
-    <roughness_anisotropy name="coat_roughness_vector" type="vector2">
+    <open_pbr_anisotropy name="coat_roughness_vector" type="vector2">
       <input name="roughness" type="float" interfacename="coat_roughness" />
       <input name="anisotropy" type="float" interfacename="coat_anisotropy" />
-    </roughness_anisotropy>
+    </open_pbr_anisotropy>
     <dielectric_bsdf name="coat_bsdf" type="BSDF">
       <input name="weight" type="float" interfacename="coat_weight" />
       <input name="tint" type="color3" value="1.0, 1.0, 1.0" />
@@ -525,6 +525,57 @@
     <!-- Output -->
     <output name="out" type="surfaceshader" nodename="shader_constructor" />
 
+  </nodegraph>
+
+  <!--
+    OpenPBR Anisotropy node definition
+  -->
+  <nodedef name="ND_open_pbr_anisotropy" node="open_pbr_anisotropy" nodegroup="pbr"
+           doc="Computes anisotropic surface roughness as defined in the OpenPBR specification.">
+    <input name="roughness" type="float" value="0.0" />
+    <input name="anisotropy" type="float" value="0.0" />
+    <output name="out" type="vector2" />
+  </nodedef>
+
+  <!--
+    OpenPBR Anisotropy graph definition
+  -->
+  <nodegraph name="NG_open_pbr_anisotropy" nodedef="ND_open_pbr_anisotropy">
+    <invert name="aniso_invert" type="float">
+      <input name="in" type="float" interfacename="anisotropy" />
+    </invert>
+    <multiply name="aniso_invert_sq" type="float">
+      <input name="in1" type="float" nodename="aniso_invert" />
+      <input name="in2" type="float" nodename="aniso_invert" />
+    </multiply>
+    <add name="denom" type="float">
+      <input name="in1" type="float" nodename="aniso_invert_sq" />
+      <input name="in2" type="float" value="1.0" />
+    </add>
+    <divide name="fraction" type="float">
+      <input name="in1" type="float" value="2.0" />
+      <input name="in2" type="float" nodename="denom" />
+    </divide>
+    <sqrt name="sqrt" type="float">
+      <input name="in" type="float" nodename="fraction" />
+    </sqrt>
+    <multiply name="rough_sq" type="float">
+      <input name="in1" type="float" interfacename="roughness" />
+      <input name="in2" type="float" interfacename="roughness" />
+    </multiply>
+    <multiply name="alpha_x" type="float">
+      <input name="in1" type="float" nodename="rough_sq" />
+      <input name="in2" type="float" nodename="sqrt" />
+    </multiply>
+    <multiply name="alpha_y" type="float">
+      <input name="in1" type="float" nodename="aniso_invert" />
+      <input name="in2" type="float" nodename="alpha_x" />
+    </multiply>
+    <combine2 name="result" type="vector2">
+      <input name="in1" type="float" nodename="alpha_x" />
+      <input name="in2" type="float" nodename="alpha_y" />
+    </combine2>
+    <output name="out" type="vector2" nodename="result" />
   </nodegraph>
 
 </materialx>


### PR DESCRIPTION
This changelist updates the anisotropy logic in the OpenPBR reference graph to match the specification.

To improve clarity and encapsulation, the new logic has been added as an 'open_pbr_anisotropy' node, which is then leveraged in the shading model graph as needed.