### PR TITLE
Rename base_roughness to base_diffuse_roughness

### DIFF
--- a/index.html
+++ b/index.html
@@ -571,7 +571,7 @@ To define the meaning of the specified color in terms of the underlying base alb
 \mathbf{E}_\textrm{glossy-diffuse} = \mathbf{E}_\textrm{spec} + \mathbf{E}_\textrm{diffuse}
 \end{eqnarray}
 where $\mathbf{E}_\mathrm{spec}$ is the normal-direction reflectance of all energy reflected from the dielectric interface without transmission, and $\mathbf{E}_\mathrm{diffuse}$ is the normal-direction reflectance of all energy transmitted through the interface, scattered off the diffuse medium, and transmitted back out.
-We then _define_ $\mathbf{C} =$ **`base_weight`** * **`base_color`** to be such that the reflectance of the remaining energy transmitted into the slab, $\mathbf{E}_\textrm{diffuse}$ in the *zero* **`base_roughness`** case (i.e. a Lambertian base), is given by
+We then _define_ $\mathbf{C} =$ **`base_weight`** * **`base_color`** to be such that the reflectance of the remaining energy transmitted into the slab, $\mathbf{E}_\textrm{diffuse}$ in the *zero* **`base_diffuse_roughness`** case (i.e. a Lambertian base), is given by
 \begin{eqnarray} \label{glossy_diffuse_albedo_constraint}
 \mathbf{E}_\textrm{diffuse} = \bigl( 1 - \mathbf{E}_\textrm{spec} \bigr) \mathbf{C} \ .
 \end{eqnarray}
@@ -590,11 +590,11 @@ f_\textrm{glossy-diffuse}(\omega_i, \omega_o) \approx f_\mathrm{dielectric}(\ome
 where $\mathcal{N}$ is a normalization factor such that equation [glossy_diffuse_albedo_constraint] is satisfied. In the case of a zero roughness (i.e. Lambertian) Oren-Nayar base $\mathcal{N}$ can be tabulated in terms of the dielectric IOR and roughness ([#Kutz2021]), and the required albedo of the Lambertian base is equal to $\mathbf{C}$ as in the non-reciprocal albedo-scaling approximation. Extending this to the more general case of a non-Lambertian rough Oren-Nayar base would require adding the roughness dimension to the tabulation, and the required Oren-Nayar albedo will not simply equal $\mathbf{C}$. We leave the specific choice of model and these details to the implementation.
 
 
-Glossy-diffuse params | Label     | Type     | Range            | Default             | Description
-----------------------|-----------|----------|:----------------:|:-------------------:|----------------------------------------------
-**`base_weight`**     | Weight    | `float`  | $ [0, 1]       $ | $ 1               $ | Scalar multiplier to **`base_color`**
-**`base_color`**      | Color     | `color3` | $ [0, 1]^3     $ | $ (0.8, 0.8, 0.8) $ | Base reflection albedo color according to equation [glossy_diffuse_albedo_constraint].
-**`base_roughness`**  | Roughness | `float`  | $ [0, 1]       $ | $ 0               $ | Roughness of the diffuse lobe $f_\mathrm{diffuse}$
+Glossy-diffuse params        | Label             | Type     | Range            | Default             | Description
+-----------------------------|-------------------|----------|:----------------:|:-------------------:|----------------------------------------------
+**`base_weight`**            | Weight            | `float`  | $ [0, 1]       $ | $ 1               $ | Scalar multiplier to **`base_color`**
+**`base_color`**             | Color             | `color3` | $ [0, 1]^3     $ | $ (0.8, 0.8, 0.8) $ | Base reflection albedo color according to equation [glossy_diffuse_albedo_constraint].
+**`base_diffuse_roughness`** | Diffuse Roughness | `float`  | $ [0, 1]       $ | $ 0               $ | Roughness of the diffuse lobe $f_\mathrm{diffuse}$
 
 
 ![](images/glossy_diffuse_diffuseonly.png width=99%) ![](images/glossy_diffuse_speconly.png width=99%) ![](images/glossy_diffuse_sum.png width=99%)

--- a/index.html
+++ b/index.html
@@ -1077,7 +1077,7 @@ In the thin-wall structure, the base slabs are interpreted as infinitesimally th
          E_R[f^R_\mathrm{diffuse}] + E_T[f^T_\mathrm{diffuse}] = S \le 1 \ .
       \end{equation}
       At the default of zero anisotropy ($g=0$) the energy is balanced equally between diffuse reflection and transmission.
-      The diffuse transmission lobe shape (in both hemispheres) is assumed to be controlled by the **`base_roughness`** parameter. Typically the diffuse lobes $f_+$, $f_-$ will be represented by an Oren-Nayar lobe flipped into the appropriate hemisphere (which technically should be modified due to the dielectric boundaries, though a renderer may choose to ignore this). This model is useful for rendering cases such as light scattering through a thin sheet of paper (Figure [thinwalled]).
+      The diffuse transmission lobe shape (in both hemispheres) is assumed to be controlled by the **`base_diffuse_roughness`** parameter. Typically the diffuse lobes $f_+$, $f_-$ will be represented by an Oren-Nayar lobe flipped into the appropriate hemisphere (which technically should be modified due to the dielectric boundaries, though a renderer may choose to ignore this). This model is useful for rendering cases such as light scattering through a thin sheet of paper (Figure [thinwalled]).
 
 
 ![](images/thin_walled1.jpg width=99% align=right) ![](images/thin_walled2.jpg width=99% align=left)

--- a/parametrization.md.html
+++ b/parametrization.md.html
@@ -24,7 +24,7 @@ To guarantee a non-ambiguous way to transport and present the model across diffe
 | **Base**                                                                                                                                        |
 | `base_weight`                         | Weight              | `float`   | $ [0, 1]        $ |               | $ 1                $ |            |
 | `base_color`                          | Color               | `color3`  | $ [0, 1]^3      $ |               | $ (0.8, 0.8, 0.8)  $ |            |
-| `base_roughness`                      | Roughness           | `float`   | $ [0, 1]        $ |               | $ 0                $ |            |
+| `base_diffuse_roughness`              | Diffuse Roughness   | `float`   | $ [0, 1]        $ |               | $ 0                $ |            |
 | `base_metalness`                      | Metalness           | `float`   | $ [0, 1]        $ |               | $ 0                $ |            |
 | **Specular**                                                                                                                                    |
 | `specular_weight`                     | Weight              | `float`   | $ [0, 1]        $ |               | $ 1                $ |            |

--- a/reference/open_pbr_surface.mtlx
+++ b/reference/open_pbr_surface.mtlx
@@ -9,7 +9,7 @@
            doc="Multiplier on the intensity of the reflection from the diffuse and metallic base." />
     <input name="base_color" type="color3" value="0.8, 0.8, 0.8" uimin="0,0,0" uimax="1,1,1" uiname="Base Color" uifolder="Base"
            doc="Color of the reflection from the diffuse and metallic base." />
-    <input name="base_roughness" type="float" value="0.0" uimin="0.0" uimax="1.0" uiname="Base Roughness" uifolder="Base" uiadvanced="true"
+    <input name="base_diffuse_roughness" type="float" value="0.0" uimin="0.0" uimax="1.0" uiname="Base Diffuse Roughness" uifolder="Base" uiadvanced="true"
            doc="Roughness of the diffuse reflection. Higher values cause the surface to appear flatter." />
     <input name="base_metalness" type="float" value="0.0" uimin="0.0" uimax="1.0" uiname="Base Metalness" uifolder="Base"
            doc="Specifies how metallic the base material appears (dials the base from pure dielectric to pure metal)." />
@@ -178,7 +178,7 @@
     <oren_nayar_diffuse_bsdf name="subsurface_thin_walled_reflection_bsdf" type="BSDF">
       <input name="weight" type="float" value="1.0" />
       <input name="color" type="color3" nodename="subsurface_color_nonnegative" />
-      <input name="roughness" type="float" interfacename="base_roughness" />
+      <input name="roughness" type="float" interfacename="base_diffuse_roughness" />
       <input name="normal" type="vector3" interfacename="geometry_normal" />
     </oren_nayar_diffuse_bsdf>
     <subtract name="one_minus_subsurface_anisotropy" type="float">
@@ -240,7 +240,7 @@
     <oren_nayar_diffuse_bsdf name="diffuse_bsdf" type="BSDF">
       <input name="weight" type="float" interfacename="base_weight" />
       <input name="color" type="color3" nodename="base_color_nonnegative" />
-      <input name="roughness" type="float" interfacename="base_roughness" />
+      <input name="roughness" type="float" interfacename="base_diffuse_roughness" />
       <input name="normal" type="vector3" interfacename="geometry_normal" />
     </oren_nayar_diffuse_bsdf>
     <convert name="subsurface_selector" type="float">


### PR DESCRIPTION
As discussed recently, it would be less ambiguous to name the diffuse roughness `base_diffuse_roughness`.

<img width="906" alt="image" src="https://github.com/AcademySoftwareFoundation/OpenPBR/assets/9511025/76c610a4-c87f-42e5-8763-0a3600fd9eb4">
<img width="900" alt="image" src="https://github.com/AcademySoftwareFoundation/OpenPBR/assets/9511025/9bf30b63-6386-4b89-8715-7cbced740900">
