### PR TITLE
Rework readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,6 @@ OpenPBR is an open standard hosted by the [Academy Software Foundation](https://
 * **[Specification](https://academysoftwarefoundation.github.io/OpenPBR/)**
 * **[Reference implementation](reference/open_pbr_surface.mtlx)** – written in [MaterialX](https://materialx.org/)
 
-### Discussion
-* **[GitHub issues](https://github.com/AcademySoftwareFoundation/OpenPBR/issues)**
-
 <br/>
 
 [![License: CC BY-SA 4.0](https://img.shields.io/badge/License-Apache%202.0-informational.svg)](LICENSE)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ OpenPBR is an open standard hosted by the [Academy Software Foundation](https://
 
 ### Resources
 
-* **[White paper](https://academysoftwarefoundation.github.io/OpenPBR/)**
+* **[Specification](https://academysoftwarefoundation.github.io/OpenPBR/)**
 * **[Reference implementation](reference/open_pbr_surface.mtlx)** – written in [MaterialX](https://materialx.org/)
 
 ### Discussion


### PR DESCRIPTION
As suggested during the discussions, this PR renames the link to the specification, and removes the link to the GitHub issues.

<img width="913" alt="image" src="https://github.com/AcademySoftwareFoundation/OpenPBR/assets/9511025/c3e7b309-70c3-4ce6-a1d0-c3bedf7b9241">
