### PR TITLE
Slightly shift TOC closer to teaser image.

### DIFF
--- a/style/style.css
+++ b/style/style.css
@@ -31,7 +31,7 @@ body
     .md .longTOC, .md .mediumTOC, .md .shortTOC
     {
         display: block;
-        margin: 20px 0 20px 30px;
+        margin: -30px 0 20px 30px;
         padding: 0;
         padding-top: 13px;
         float: initial;


### PR DESCRIPTION
Just a trivial tweak to reduce whitespace between the teaser images and the TOC:

![image](https://github.com/AcademySoftwareFoundation/OpenPBR/assets/2774364/c49bf423-6d18-44cb-a797-71bb1c01b80f)
