### PR TITLE
Add coat_darkening to default example

### DIFF
--- a/examples/open_pbr_default.mtlx
+++ b/examples/open_pbr_default.mtlx
@@ -34,6 +34,7 @@
     <input name="coat_roughness" type="float" value="0.0" />
     <input name="coat_roughness_anisotropy" type="float" value="0.0" />
     <input name="coat_ior" type="float" value="1.6" />
+    <input name="coat_darkening" type="float" value="1.0" />
     <input name="thin_film_weight" type="float" value="0.0" />
     <input name="thin_film_thickness" type="float" value="0" />
     <input name="thin_film_ior" type="float" value="1.5" />


### PR DESCRIPTION
This changelist adds the coat_darkening input to our default material example, improving the visibility of this control in user testing.