### PR TITLE
Enable diffuse energy compensation

### DIFF
--- a/reference/open_pbr_surface.mtlx
+++ b/reference/open_pbr_surface.mtlx
@@ -201,6 +201,7 @@
       <input name="color" type="color3" nodename="base_color_nonnegative" />
       <input name="roughness" type="float" interfacename="base_diffuse_roughness" />
       <input name="normal" type="vector3" interfacename="geometry_normal" />
+      <input name="energy_compensation" type="boolean" value="true" />
     </oren_nayar_diffuse_bsdf>
     <convert name="subsurface_selector" type="float">
       <input name="in" type="boolean" interfacename="geometry_thin_walled" />


### PR DESCRIPTION
This changelist adds the `energy_compensation` setting to `oren_nayar_diffuse_bsdf` in the reference implementation for OpenPBR, leveraging the upcoming support for this feature in MaterialX 1.39.

In recent MaterialX TSC meetings, we've aligned on this naming convention for the new energy compensation feature in oren_nayar_diffuse_bsdf, and it now seems safe to move forward with this setting in OpenPBR v1.0.