### PR TITLE
Implement TIR fix in MaterialX

### DIFF
--- a/reference/open_pbr_surface.mtlx
+++ b/reference/open_pbr_surface.mtlx
@@ -304,12 +304,23 @@
     </multiply>
 
     <!-- Dielectric Base -->
-    <divide name="specular_to_coat_ior_ratio" type="float">
-      <input name="in1" type="float" interfacename="specular_ior" />
-      <input name="in2" type="float" interfacename="coat_ior" />
-    </divide>
+      <!-- apply IOR ratio inversion method to avoid TIR artifact (as in Coat TIR section of spec) -->
+      <divide name="specular_to_coat_ior_ratio" type="float">
+         <input name="in1" type="float" interfacename="specular_ior" />
+         <input name="in2" type="float" interfacename="coat_ior" />
+      </divide>
+      <divide name="coat_to_specular_ior_ratio" type="float">
+         <input name="in1" type="float" interfacename="coat_ior" />
+         <input name="in2" type="float" interfacename="specular_ior" />
+      </divide>
+      <ifgreater name="specular_to_coat_ior_ratio_tir_fix" type="float">
+         <input name="value1" type="float" nodename="specular_to_coat_ior_ratio" />
+         <input name="value2" type="float" value="1.0" />
+         <input name="in1" type="float" nodename="specular_to_coat_ior_ratio" />
+         <input name="in2" type="float" nodename="coat_to_specular_ior_ratio" />
+      </ifgreater>
     <mix name="eta_s" type="float">
-      <input name="fg" type="float" nodename="specular_to_coat_ior_ratio" />
+      <input name="fg" type="float" nodename="specular_to_coat_ior_ratio_tir_fix" />
       <input name="bg" type="float" interfacename="specular_ior" />
       <input name="mix" type="float" interfacename="coat_weight" />
     </mix>


### PR DESCRIPTION
Without fix:

![image](https://github.com/AcademySoftwareFoundation/OpenPBR/assets/2774364/ee489236-914a-4e97-80b5-52ead741b18f)

With fix:

![image](https://github.com/AcademySoftwareFoundation/OpenPBR/assets/2774364/5b995236-f9e7-441f-8849-b43e95884770)

(In the `MaterialXView` app though, I don't see the difference. I'm not sure why, perhaps the original code is being pulled somehow?).