### PR TITLE
Add uiname field to .mtlx nodedef

### DIFF
--- a/reference/open_pbr_surface.mtlx
+++ b/reference/open_pbr_surface.mtlx
@@ -4,7 +4,7 @@
     OpenPBR Surface node definition
   -->
   <nodedef name="ND_open_pbr_surface_surfaceshader" node="open_pbr_surface" nodegroup="pbr" version="0.5" isdefaultversion="true"
-           doc="OpenPBR Surface Shading Model">
+           doc="OpenPBR Surface Shading Model" uiname="OpenPBR Surface">
     <input name="base_weight" type="float" value="1.0" uimin="0.0" uimax="1.0" uiname="Base Weight" uifolder="Base"
            doc="Multiplier on the intensity of the reflection from the diffuse and metallic base." />
     <input name="base_color" type="color3" value="0.8, 0.8, 0.8" uimin="0,0,0" uimax="1,1,1" uiname="Base Color" uifolder="Base"


### PR DESCRIPTION
Since the Maya team noted that they need this field in order to derive the node name (with correct capitalization and word break) to show in the editor:
>since the name of the node is open_pbr_surface, it will require custom code to turn it into "OpenPBR Surface".

>uiname metadata is already in the MaterialX specifications in the "[Custom Node Declaration NodeDef Elements](https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/documents/Specification/MaterialX.Specification.md#custom-node-declaration-nodedef-elements)" section for MaterialX 1.39 and I see this as well in the old 1.38 specification. Feel free to add it to OpenPBR surface and I will make sure LookdevX uses it.