### PR TITLE
Diffuse base_weight description changed to match MaterialX EON implementation

### DIFF
--- a/index.html
+++ b/index.html
@@ -604,7 +604,9 @@ where $f_\mathrm{diffuse}$ is based on the classic Oren-Nayar model ([#Oren1994]
     ![Figure [rough_diffuse]: Zero roughness ($\sigma=0$, left) and maximum roughness ($\sigma=1$, right) diffuse materials with $\textbf{EON}$ BRDF.](dummy)
 </div>
 
-Unfortunately, the original model suffers from artifacts and also does not conserve energy (i.e. is too dark). We thus opt to define the diffuse BRDF to be a popular improved version of Oren-Nayar introduced by [#Fujii2012], augmented with a simple analytical, reciprocal energy compensation term:
+Unfortunately, the original model suffers from artifacts and also does not conserve energy (i.e. is too dark). We thus
+opt to define the diffuse BRDF to be a popular improved version of Oren-Nayar introduced by Fujii [#Fujii2012],
+augmented with a simple analytical, reciprocal energy compensation term:
 \begin{eqnarray} \label{EON_brdf}
 f_\mathrm{diffuse}(\omega_i, \omega_o) = f_\mathrm{ON}(\omega_i, \omega_o) + f^\mathrm{comp}_\mathrm{ON}(\omega_i, \omega_o) \ .
 \end{eqnarray}

--- a/index.html
+++ b/index.html
@@ -1302,7 +1302,8 @@ The "specular" BTDF/BSSRDF $\color{darkblue}{f^T_\textrm{specular}}$ corresponds
 
 Note that in this albedo-scaling approximation, the transmission Fresnel factor associated with $\color{darkblue}{f^T_\textrm{specular}}$ and $f_\textrm{SSS}$ can be *omitted* as the energy conservation of the dielectric BSDF as a whole is maintained automatically, even without explicit multiple scattering compensation or in the presence of modifications to the reflection Fresnel factor via **`specular_color`**.
 
-Since $\color{darkblue}{f^R_\textrm{specular}}$ appears in each of the three components slab of the dielectric base, it follows that on collecting terms, $f_\textrm{dielectric-base}$ reduces to:
+Since $\color{darkblue}{f^R_\textrm{specular}}$ appears in each of the three component slabs of the dielectric base, it
+follows that on collecting terms, $f_\textrm{dielectric-base}$ reduces to:
 \begin{equation}
 f_\textrm{dielectric-base} = \color{darkblue}{f^R_\textrm{specular}}  + (1 - E[\color{darkblue}{f^R_\textrm{specular}}]) \,f^T_\mathrm{dielectric-base} \ ,
 \end{equation}

--- a/index.html
+++ b/index.html
@@ -609,13 +609,19 @@ f_\mathrm{diffuse}(\omega_i, \omega_o) = f_\mathrm{ON}(\omega_i, \omega_o) + f^\
 This form of the Oren-Nayar model is termed "energy-preserving Oren-Nayar" or $\textbf{EON}$.
 The Oren-Nayar term $f_\mathrm{ON}$ is given by the [#Fujii2012] form [^Oren_Nayar_formula]
 \begin{eqnarray} \label{FON_brdf}
-f_\mathrm{ON}(\omega_i, \omega_o) = \frac{\boldsymbol{\rho}}{\pi} \Bigl( A(\sigma) + B(\sigma) \frac{s}{t} \Bigr) \ .
+f_\mathrm{ON}(\omega_i, \omega_o) = \frac{w_\mathrm{d} \boldsymbol{\rho}}{\pi} \Bigl( A(\sigma) + B(\sigma) \frac{s}{t}
+\Bigr) \ .
 \end{eqnarray}
-The roughness parameter $\sigma \in [0,1]$ is given by **`base_diffuse_roughness`**. The RGB $\boldsymbol{\rho}$ parameter is determined by the specified **`base_color`**, as described below. The directional albedo $E_\mathrm{ON}(\omega) = \boldsymbol{\rho}\,\hat{E}_\mathrm{ON}(\omega)$ (and corresponding _average albedo_ $\langle\hat{E}_\mathrm{ON}\rangle$) of the Oren-Nayar term can be determined analytically [^Oren_Nayar_albedo].
+The roughness parameter $\sigma \in [0,1]$ is given by **`base_diffuse_roughness`**. The overall weight
+$w_\mathrm{d}$ = **`base_weight`**.
+The RGB $\boldsymbol{\rho}$ parameter is determined by the specified **`base_color`**, as described below.
 
-The energy compensation term $f^{\mathrm{comp}}_\mathrm{ON}$ is given in terms of the albedo $\langle\hat{E}_\mathrm{ON}\rangle$ by
+The directional albedo $E_\mathrm{ON}(\omega) = w_\mathrm{d} \boldsymbol{\rho}\,\hat{E}_\mathrm{ON}(\omega)$, and
+corresponding _average albedo_ $\langle\hat{E}_\mathrm{ON}\rangle$, of the Oren-Nayar term can be determined
+analytically [^Oren_Nayar_albedo]. The energy compensation term $f^{\mathrm{comp}}_\mathrm{ON}$ is given in terms of the
+albedo $\langle\hat{E}_\mathrm{ON}\rangle$ by
 \begin{equation} \label{EON_comp}
-f^\mathrm{comp}_\mathrm{ON}(\omega_i, \omega_o) = \frac{\boldsymbol{\rho}_\mathrm{ms}}{\pi}
+f^\mathrm{comp}_\mathrm{ON}(\omega_i, \omega_o) = \frac{w_\mathrm{d} \boldsymbol{\rho}_\mathrm{ms}}{\pi}
 \bigl(1 - \hat{E}_\mathrm{ON}(\omega_i)\bigr)
 \bigl(1 - \hat{E}_\mathrm{ON}(\omega_o)\bigr) \ ,
 \end{equation}
@@ -624,16 +630,29 @@ where the factor $\boldsymbol{\rho}_\mathrm{ms}$ accounts approximately for mult
 \boldsymbol{\rho}_\mathrm{ms} = \frac{\boldsymbol{\rho}^2}{\pi}
 \frac{\langle\hat{E}_\mathrm{ON}\rangle / (1 - \langle \hat{E}_\mathrm{ON}\rangle)}{1 - \boldsymbol{\rho} \bigl(1 - \langle \hat{E}_\mathrm{ON}\rangle\bigr)} \ .
 \end{equation}
-One can verify that as $\boldsymbol{\rho} \rightarrow 1$, the total directional albedo of the BRDF of Equation [EON_brdf], $E_\mathrm{diffuse}(\omega) \rightarrow 1$, thus the compensation term ensures that the white furnace test passes. Note that in the the zero roughness ($\sigma \rightarrow 0$) limit, the energy compensation term vanishes, and the parameter $\boldsymbol{\rho}$ is equal to the albedo of $f_\mathrm{diffuse}$. As roughness increases, the albedo of $f_\mathrm{diffuse}$ becomes slightly more dark and saturated than $\boldsymbol{\rho}$ due to the multiple scattering, which is physically realistic.
+One can verify that as $\boldsymbol{\rho} \rightarrow 1$, the total directional albedo of the BRDF of Equation
+[EON_brdf], $E_\mathrm{diffuse}(\omega) \rightarrow 1$ (in the $w_\mathrm{d}=1$ case), thus the compensation term
+ensures that the white furnace test passes. Note that in the the zero roughness ($\sigma \rightarrow 0$) limit, the
+energy compensation term vanishes, and the parameter $\boldsymbol{\rho}$ is equal to the albedo of $f_\mathrm{diffuse}$.
+As roughness increases, the albedo of $f_\mathrm{diffuse}$ becomes slightly more dark and saturated than
+$\boldsymbol{\rho}$ due to the multiple scattering, which is physically realistic.
 
-Physically there will be additional darkening and saturation of the observed color due to multiple inter-reflections (scattering) within the gloss layer, as described in the coat darkening section. However in this case, we wish to automatically compensate for this effect by adjusting the $\boldsymbol{\rho}$ parameter of $f_\mathrm{diffuse}$ in order to make the observed color match the input color $\mathbf{C} =$ **`base_weight`** * **`base_color`** (in a similar spirit to the albedo remapping described in the Subsurface section).
-To define the meaning of the specified color in terms of the underlying base albedo, we write the normal-direction reflectance of the glossy-diffuse slab, $\mathbf{E}_\textrm{glossy-diffuse}$ in the general form
+Physically there will be additional darkening and saturation of the observed color due to multiple inter-reflections
+(scattering) within the gloss layer, as described in the coat darkening section. However in this case, we wish to
+automatically compensate for this effect by adjusting the $\boldsymbol{\rho}$ parameter of $f_\mathrm{diffuse}$ in order
+to make the observed color match the input color $\mathbf{C} =$ **`base_color`** (in a similar spirit to the albedo
+remapping described in the Subsurface section).
+To define the meaning of the specified color in terms of the underlying base albedo, we write the normal-direction
+reflectance of the glossy-diffuse slab (in the $w_\mathrm{d}=1$ case), $\mathbf{E}_\textrm{glossy-diffuse}$ in the
+general form
 \begin{eqnarray}
 \mathbf{E}_\textrm{glossy-diffuse} = \mathbf{E}_\textrm{spec} + \mathbf{E}_\textrm{diffuse}
 \end{eqnarray}
 where $\mathbf{E}_\mathrm{spec}$ is the normal-direction reflectance of all energy reflected from the dielectric interface _without_ macroscopic transmission, while $\mathbf{E}_\mathrm{diffuse}$ is the normal-direction reflectance of all remaining energy due to (macroscopic) transmission through the interface, multiple scattering in the diffuse medium, and transmission back out.
 
-We then _define_ $\mathbf{C} =$ **`base_weight`** * **`base_color`** to be such that the reflectance of the remaining energy transmitted into the slab, $\mathbf{E}_\textrm{diffuse}$ in the Lambertian case of  *zero* **`base_diffuse_roughness`** (i.e. $\sigma = 0$), is given by
+We then _define_ $\mathbf{C} =$ **`base_color`** to be such that the reflectance of the remaining energy transmitted
+into the slab, $\mathbf{E}_\textrm{diffuse}$ in the Lambertian case of *zero* **`base_diffuse_roughness`** (i.e. $\sigma
+= 0$), is given by
 \begin{eqnarray} \label{glossy_diffuse_albedo_constraint}
 \mathbf{E}_\textrm{diffuse} = \bigl( 1 - \mathbf{E}_\textrm{spec} \bigr) \mathbf{C} \ .
 \end{eqnarray}
@@ -649,12 +668,19 @@ If a reciprocal formulation is desired, the classic Ashikhmin-Shirley or Kelemen
 \begin{equation}
 f_\textrm{glossy-diffuse}(\omega_i, \omega_o) \approx f_\mathrm{dielectric}(\omega_i, \omega_o)  + \mathcal{N} \bigl(1 - E_\mathrm{dielectric}(\omega_i)\bigr) \bigl(1 - E_\mathrm{dielectric}(\omega_o)\bigr) \,f_\mathrm{diffuse}(\omega_i, \omega_o) \ ,
 \end{equation}
-where $\mathcal{N}$ is a normalization factor such that equation [glossy_diffuse_albedo_constraint] is satisfied. In the case of a zero roughness (i.e. Lambertian) Oren-Nayar base $\mathcal{N}$ can be tabulated in terms of the dielectric IOR ([#Kutz2021]), and the required $\boldsymbol{\rho}$ of the Lambertian base is equal to $\mathbf{C}$ as in the non-reciprocal albedo-scaling approximation. Extending this to the more general case of a non-Lambertian rough Oren-Nayar base would require adding the roughness dimension to the tabulation, and the required Oren-Nayar $\boldsymbol{\rho}$ will not simply equal $\mathbf{C}$. We leave the specific choice of model and these details to the implementation.
+where $\mathcal{N}$ is a normalization factor such that equation [glossy_diffuse_albedo_constraint] is satisfied. In the
+case of a zero roughness (i.e. Lambertian) Oren-Nayar base $\mathcal{N}$ can be tabulated in terms of the dielectric IOR
+([#Kutz2021]), and the required $\boldsymbol{\rho}$ of the Lambertian base is equal to $\mathbf{C}$ as in the
+non-reciprocal albedo-scaling approximation. Extending this to the more general case of a non-Lambertian rough
+Oren-Nayar base would require adding the roughness dimension to the tabulation, and the required Oren-Nayar
+$\boldsymbol{\rho}$ will then _not_ simply equal $\mathbf{C}$. We leave the specific choice of model and these details
+to
+the implementation.
 
 
 Glossy-diffuse params        | Label             | Type     | Range            | Default             | Description
 -----------------------------|-------------------|----------|:----------------:|:-------------------:|----------------------------------------------
-**`base_weight`**            | Weight            | `float`  | $ [0, 1]       $ | $ 1               $ | Scalar multiplier to **`base_color`**
+**`base_weight`** | Weight | `float` | $ [0, 1] $ | $ 1 $ | Scalar multiplier of $f_\mathrm{diffuse}$
 **`base_color`**             | Color             | `color3` | $ [0, 1]^3     $ | $ (0.8, 0.8, 0.8) $ | Base reflection albedo color according to equation [glossy_diffuse_albedo_constraint].
 **`base_diffuse_roughness`** | Diffuse Roughness | `float`  | $ [0, 1]       $ | $ 0               $ | Roughness of the diffuse lobe $f_\mathrm{diffuse}$
 
@@ -1439,16 +1465,14 @@ Frankie Liu,
 André Mazzone,
 Nikie Monteleone,
 Michael Nickelsky,
-Anton Palmqvist,
 Guido Quaroni,
 Nathan Reed,
 Anthony Salvi,
 Lukas Stockner,
 Masuo Suzuki,
-Brecht van Lommel,
-Andrea Weidlich
+Brecht van Lommel
 and
-Nicolas Wirrmann
+Andrea Weidlich
 for their useful contributions.
 
 

--- a/index.html
+++ b/index.html
@@ -1457,6 +1457,7 @@ The authors would also like to thank
 François Beaune,
 Henrik Edstrom,
 Eugene d'Eon,
+Jerry Gamache,
 Iliyan Georgiev,
 Lee Griggs,
 Niklas Harrysson,
@@ -1465,17 +1466,20 @@ Stephen Hill,
 Chris Kulla,
 Anders Langlands,
 Frankie Liu,
+Thomas Makryniotis,
 André Mazzone,
 Nikie Monteleone,
 Michael Nickelsky,
+Anton Palmqvist,
 Guido Quaroni,
 Nathan Reed,
 Anthony Salvi,
 Lukas Stockner,
 Masuo Suzuki,
-Brecht van Lommel
-and
+Brecht van Lommel,
 Andrea Weidlich
+and
+Nicolas Wirrmann
 for their useful contributions.
 
 

--- a/index.html
+++ b/index.html
@@ -574,7 +574,8 @@ Metal params                        | Label      | Type     | Range        | Def
 
 The glossy-diffuse slab represents the base dielectric (parametrized as described in the Dielectric base section), embedding a semi-infinite bulk of extremely dense scattering material. The BRDF of the slab is the combination of a "glossy" specular lobe provided by immediate reflection from the dielectric interface, and a diffuse lobe provided by scattering off the embedded substrate. This models for example the reflection from shiny, totally opaque surfaces such as dense plastic, rock, and concrete.
 
-We choose to model this concretely as a layer of dielectric "gloss" on top of an opaque slab with a diffuse BRDF:
+We choose to model this concretely as a layer of dielectric "gloss" on top of an (index-matched) opaque slab with a
+diffuse BRDF:
 \begin{eqnarray}
 M_\textrm{glossy-diffuse} = \mathrm{\mathbf{layer}}(S_\mathrm{diffuse}, S_\textrm{gloss})
 \end{eqnarray}
@@ -591,7 +592,8 @@ where $S_\textrm{gloss}$ is a thin slab of dielectric with the rough dielectric 
 \begin{eqnarray}
 S_\textrm{gloss} = \mathrm{Slab}(f_\mathrm{dielectric}, V_\mathrm{dielectric})  \ .
 \end{eqnarray}
-The opaque substrate slab has a diffuse BRDF lobe:
+Since the diffuse base is index-matched with the gloss, Fresnel reflection is only generated from the top interface of
+the gloss. The opaque substrate slab has a diffuse BRDF lobe:
 \begin{eqnarray}
 S_\textrm{diffuse}    = \mathrm{Slab}(f_\mathrm{diffuse})
 \end{eqnarray}


### PR DESCRIPTION
As discussed in https://github.com/AcademySoftwareFoundation/MaterialX/pull/1822#issuecomment-2127738467, the MaterialX implementation assumed that the `base_weight` acts as an overall multiplier of the EON BRDF. While in the OpenPBR spec, we had `base_weight` instead multiplying `base_color`.

In fact the MaterialX intepretation seems better, since then the `base_weight` functions as a linear modulation of the overall albedo, rather than doing something non-linear and dependent on the color. This PR makes the necessary changes to the wording/math of the spec to implement this.

![image](https://github.com/AcademySoftwareFoundation/OpenPBR/assets/2774364/a67b5c9e-9314-429b-b10d-f068400240f3)

![image](https://github.com/AcademySoftwareFoundation/OpenPBR/assets/2774364/6dc2d85e-8f4d-463c-86c0-e73f2810e124)
