### PR TITLE
Change thin film IOR default

### DIFF
--- a/examples/open_pbr_default.mtlx
+++ b/examples/open_pbr_default.mtlx
@@ -37,7 +37,7 @@
     <input name="coat_darkening" type="float" value="1.0" />
     <input name="thin_film_weight" type="float" value="0.0" />
     <input name="thin_film_thickness" type="float" value="0" />
-    <input name="thin_film_ior" type="float" value="1.5" />
+    <input name="thin_film_ior" type="float" value="1.4" />
     <input name="emission_luminance" type="float" value="0.0" />
     <input name="emission_color" type="color3" value="1, 1, 1" />
     <input name="geometry_opacity" type="float" value="1" />

--- a/index.html
+++ b/index.html
@@ -838,7 +838,7 @@ Thin-film params          | Label     | Type     | Range           | Norm       
 --------------------------|-----------|----------|:---------------:|:-------------:|:--------:|----------------------------------------------
 **`thin_film_weight`**    | Weight    | `float`  | $ [0, 1]      $ |               | $ 0    $ | Coverage weight of the thin film
 **`thin_film_thickness`** | Thickness | `float`  | $ [0, \infty) $ | $ [0, 1]    $ | $ 0.5  $ | Thickness of the film in micrometers ($\mathrm{\mu m}$)
-**`thin_film_ior`**       | IOR       | `float`  | $ (0, \infty) $ | $ [1, 3]    $ | $ 1.5  $ | Refractive index of the film
+**`thin_film_ior`**       | IOR       | `float`  | $ (0, \infty) $ | $ [1, 3]    $ | $ 1.4  $ | Refractive index of the film
 
 ![](images/thin_film_0nm.png width=99%) ![](images/thin_film_300nm.png width=99%) ![](images/thin_film_600nm.png width=99%)
 <div class="shifted-caption">

--- a/parametrization.md.html
+++ b/parametrization.md.html
@@ -63,7 +63,7 @@ To guarantee a non-ambiguous way to transport and present the model across diffe
 | **Thin-film**                                                                                                                                         |
 | `thin_film_weight`                    | Weight              | `float`   | $ [0, 1]        $ |               | $ 0                $ |                  |
 | `thin_film_thickness`                 | Thickness           | `float`   | $ [0, \infty)   $ | $ [0, 1] $    | $ 0.5              $ | $\mathrm{\mu m}$ |
-| `thin_film_ior`                       | IOR                 | `float`   | $ (0, \infty)   $ | $ [1, 3]    $ | $ 1.5              $ |                  |
+| `thin_film_ior`                       | IOR                 | `float`   | $ (0, \infty)   $ | $ [1, 3]    $ | $ 1.4              $ |                  |
 | **Geometry**                                                                                                                                          |
 | `geometry_opacity`                    | Opacity             | `float`   | $ [0, 1]        $ |               | $ 1                $ |                  |
 | `geometry_thin_walled`                | Thin walled         | `boolean` | {false, true}     |               | false                |                  |

--- a/reference/open_pbr_surface.mtlx
+++ b/reference/open_pbr_surface.mtlx
@@ -69,7 +69,7 @@
            doc="Coverage weight of the thin-film. Use for materials such as multi-tone car paint or soap bubbles." />
     <input name="thin_film_thickness" type="float" value="0.5" uimin="0.0" uisoftmax="1.0" uiname="Thin Film Thickness" uifolder="Thin Film" uiadvanced="true"
            doc="The thickness of the thin-film layer on the base (in micrometers)." />
-    <input name="thin_film_ior" type="float" value="1.5" uimin="0.0" uisoftmin="1.0" uisoftmax="3.0" uiname="Thin Film Index of Refraction" uifolder="Thin Film" uiadvanced="true"
+    <input name="thin_film_ior" type="float" value="1.4" uimin="0.0" uisoftmin="1.0" uisoftmax="3.0" uiname="Thin Film Index of Refraction" uifolder="Thin Film" uiadvanced="true"
            doc="The index of refraction of the thin-film." />
     <input name="emission_luminance" type="float" value="0.0" uimin="0.0" uisoftmax="1000.0" uiname="Emission Luminance" uifolder="Emission"
            doc="The amount of emitted light, as a luminance in nits." />


### PR DESCRIPTION
From 1.5 to 1.4.  

As this won't make much difference to the look in implementations that ignore the adjacent IORs of the film.

But for those that take it into account, this will make the film visible rather than invisible by default (since `specular_ior` is 1.5 by default, and `coat_ior` 1.6).