### PR TITLE
Update BibTeX citation (date, and capitalization)

### DIFF
--- a/openpbr.bib
+++ b/openpbr.bib
@@ -1,6 +1,6 @@
 @techreport{OpenPBR,
   author = {Zap Andersson and Paul Edmondson and Julien Guertault and Adrien Herubel and Alan King and Peter Kutz and Andréa Machizaud and Jamie Portsmouth and Frédéric Servant and Jonathan Stone},
-  title = {{O}pen{PBR} {S}urface},
+  title = {{O}pen{PBR} {S}urface Specification},
   institution = {Academy Software Foundation ({ASWF})},
   year = {2024},
   month = {June},

--- a/openpbr.bib
+++ b/openpbr.bib
@@ -3,6 +3,5 @@
   title = {{O}pen{PBR} {S}urface Specification},
   institution = {Academy Software Foundation ({ASWF})},
   year = {2024},
-  month = {June},
   url = {https://academysoftwarefoundation.github.io/OpenPBR/}
 }

--- a/openpbr.bib
+++ b/openpbr.bib
@@ -1,8 +1,8 @@
 @techreport{OpenPBR,
   author = {Zap Andersson and Paul Edmondson and Julien Guertault and Adrien Herubel and Alan King and Peter Kutz and Andréa Machizaud and Jamie Portsmouth and Frédéric Servant and Jonathan Stone},
-  title = {OpenPBR Surface},
-  institution = {Academy Software Foundation (ASWF)},
+  title = {{O}pen{PBR} {S}urface},
+  institution = {Academy Software Foundation ({ASWF})},
   year = {2024},
-  month = {May},
+  month = {June},
   url = {https://academysoftwarefoundation.github.io/OpenPBR/}
 }


### PR DESCRIPTION
Updating the date to June.

Also forcing capitalization, so e.g. in journals (such as JCGT) which (annoyingly) render the titles by default as all lowercase, the capitalization of OpenPBR is retained, e.g. in JCGT:

![image](https://github.com/AcademySoftwareFoundation/OpenPBR/assets/2774364/45849225-6061-4d3c-9197-07a5bff2fb12)

