### PR TITLE
Add a "resources" section to the front page

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ OpenPBR Surface is an open standard hosted by the [Academy Software Foundation](
 
 ### Resources
 
-* [MaterialX Web Viewer](https://academysoftwarefoundation.github.io/MaterialX/?file=Materials/Examples/OpenPbr/open_pbr_default.mtlx) - WebGL   rasterization renderer using MaterialX [implementation](reference/open_pbr_surface.mtlx) of OpenPBR
+* [MaterialX Web Viewer](https://academysoftwarefoundation.github.io/MaterialX/?file=Materials/Examples/OpenPbr/open_pbr_default.mtlx) - WebGL rasterization renderer using MaterialX [implementation](reference/open_pbr_surface.mtlx) of OpenPBR
 * [OpenPBR-viewer](https://github.com/portsmouth/OpenPBR-viewer) - self-contained example implementation in a WebGL pathtracer (run [here](https://portsmouth.github.io/OpenPBR-viewer))
 * [#openpbr](https://academysoftwarefdn.slack.com/channels/openpbr) - public Slack channel for discussions, hosted by ASWF
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ OpenPBR Surface is an open standard hosted by the [Academy Software Foundation](
 
 ### Resources
 
-* [MaterialX web-viewer](https://academysoftwarefoundation.github.io/MaterialX/?file=Materials/Examples/OpenPbr/open_pbr_default.mtlx) - WebGL test renderer using MaterialX [implementation](reference/open_pbr_surface.mtlx) of OpenPBR
+* [MaterialX Web Viewer](https://academysoftwarefoundation.github.io/MaterialX/?file=Materials/Examples/OpenPbr/open_pbr_default.mtlx) - WebGL test renderer using MaterialX [implementation](reference/open_pbr_surface.mtlx) of OpenPBR
 * [OpenPBR-viewer](https://github.com/portsmouth/OpenPBR-viewer) - self-contained example implementation in a WebGL pathtracer (run [here](https://portsmouth.github.io/OpenPBR-viewer))
 * [#openpbr](https://academysoftwarefdn.slack.com/channels/openpbr) - public Slack channel for discussions, hosted by ASWF
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ OpenPBR Surface is an open standard hosted by the [Academy Software Foundation](
 ### Resources
 
 * [MaterialX web-viewer](https://academysoftwarefoundation.github.io/MaterialX/?file=Materials/Examples/OpenPbr/open_pbr_default.mtlx) - uses MaterialX's GLSL implementation of OpenPBR
-* [OpenPBR-viewer](https://github.com/portsmouth/OpenPBR-viewer) - an self-contained example implementation in a WebGL pathtracer (run web app [here](https://portsmouth.github.io/OpenPBR-viewer))
+* [OpenPBR-viewer](https://github.com/portsmouth/OpenPBR-viewer) - a self-contained example implementation in a WebGL pathtracer (run web app [here](https://portsmouth.github.io/OpenPBR-viewer))
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ OpenPBR Surface is an open standard hosted by the [Academy Software Foundation](
 * **[Reference implementation](reference/open_pbr_surface.mtlx)** – written in [MaterialX](https://materialx.org/)
 * **[BibTeX citation](openpbr.bib)**
 
+### Resources
+
+* [MaterialX web-viewer](https://academysoftwarefoundation.github.io/MaterialX/?file=Materials/Examples/OpenPbr/open_pbr_default.mtlx) - uses MaterialX's GLSL implementation of OpenPBR
+* [OpenPBR-viewer](https://github.com/portsmouth/OpenPBR-viewer) - an self-contained example implementation in a WebGL pathtracer (run web app [here](https://portsmouth.github.io/OpenPBR-viewer))
+
 <br/>
 
 [![License: CC BY-SA 4.0](https://img.shields.io/badge/License-Apache%202.0-informational.svg)](LICENSE)

--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ OpenPBR Surface is an open standard hosted by the [Academy Software Foundation](
 
 ### Resources
 
-* [MaterialX web-viewer](https://academysoftwarefoundation.github.io/MaterialX/?file=Materials/Examples/OpenPbr/open_pbr_default.mtlx) - uses MaterialX's GLSL implementation of OpenPBR
-* [OpenPBR-viewer](https://github.com/portsmouth/OpenPBR-viewer) - a self-contained example implementation in a WebGL pathtracer (run web app [here](https://portsmouth.github.io/OpenPBR-viewer))
+* [#openpbr](https://academysoftwarefdn.slack.com/channels/openpbr) - public Slack channel for discussions, hosted by ASWF
+* [MaterialX web-viewer](https://academysoftwarefoundation.github.io/MaterialX/?file=Materials/Examples/OpenPbr/open_pbr_default.mtlx) - WebGL test renderer using MaterialX [implementation](reference/open_pbr_surface.mtlx) of OpenPBR
+* [OpenPBR-viewer](https://github.com/portsmouth/OpenPBR-viewer) - self-contained example implementation in a WebGL pathtracer (run [here](https://portsmouth.github.io/OpenPBR-viewer))
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ OpenPBR Surface is an open standard hosted by the [Academy Software Foundation](
 
 * **[White paper](https://academysoftwarefoundation.github.io/OpenPBR/)**
 * **[Parameter reference](https://academysoftwarefoundation.github.io/OpenPBR/#parameterreference)**
-* **[MaterialX reference implementation](reference/open_pbr_surface.mtlx)**
+* **[Reference implementation](reference/open_pbr_surface.mtlx)** – written in [MaterialX](https://materialx.org/)
 * **[BibTeX citation](openpbr.bib)**
 
 ### Resources
 
-* [MaterialX Web Viewer](https://academysoftwarefoundation.github.io/MaterialX/?file=Materials/Examples/OpenPbr/open_pbr_default.mtlx) - WebGL test renderer using MaterialX [implementation](reference/open_pbr_surface.mtlx) of OpenPBR
+* [MaterialX Web Viewer](https://academysoftwarefoundation.github.io/MaterialX/?file=Materials/Examples/OpenPbr/open_pbr_default.mtlx) - WebGL   rasterization renderer using MaterialX [implementation](reference/open_pbr_surface.mtlx) of OpenPBR
 * [OpenPBR-viewer](https://github.com/portsmouth/OpenPBR-viewer) - self-contained example implementation in a WebGL pathtracer (run [here](https://portsmouth.github.io/OpenPBR-viewer))
 * [#openpbr](https://academysoftwarefdn.slack.com/channels/openpbr) - public Slack channel for discussions, hosted by ASWF
 

--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ OpenPBR Surface is an open standard hosted by the [Academy Software Foundation](
 
 * **[White paper](https://academysoftwarefoundation.github.io/OpenPBR/)**
 * **[Parameter reference](https://academysoftwarefoundation.github.io/OpenPBR/#parameterreference)**
-* **[Reference implementation](reference/open_pbr_surface.mtlx)** – written in [MaterialX](https://materialx.org/)
+* **[MaterialX reference implementation](reference/open_pbr_surface.mtlx)**
 * **[BibTeX citation](openpbr.bib)**
 
 ### Resources
 
-* [#openpbr](https://academysoftwarefdn.slack.com/channels/openpbr) - public Slack channel for discussions, hosted by ASWF
 * [MaterialX web-viewer](https://academysoftwarefoundation.github.io/MaterialX/?file=Materials/Examples/OpenPbr/open_pbr_default.mtlx) - WebGL test renderer using MaterialX [implementation](reference/open_pbr_surface.mtlx) of OpenPBR
 * [OpenPBR-viewer](https://github.com/portsmouth/OpenPBR-viewer) - self-contained example implementation in a WebGL pathtracer (run [here](https://portsmouth.github.io/OpenPBR-viewer))
+* [#openpbr](https://academysoftwarefdn.slack.com/channels/openpbr) - public Slack channel for discussions, hosted by ASWF
 
 <br/>
 


### PR DESCRIPTION
With links to
  - MaterialX web viewer running OpenPBR default material
  - OpenPBR-viewer project and web app
  
![image](https://github.com/AcademySoftwareFoundation/OpenPBR/assets/2774364/e2bba848-bc7c-40a1-9aa1-ca5d50f05f68)

