### PR TITLE
Update subsurface color types

### DIFF
--- a/index.html
+++ b/index.html
@@ -750,7 +750,7 @@ Subsurface params                   | Label        | Type      | Range          
 **`subsurface_weight`**             | Weight       | `float`   | $ [0, 1]      $ |            | $ 0                $ | Mix weight between subsurface and diffuse slabs
 **`subsurface_color`**              | Color        | `color3`  | $ [0, 1]      $ |            | $ (0.8, 0.8, 0.8)  $ | The observed reflection color of $V^\infty_\mathrm{subsurface}$
 **`subsurface_radius`**             | Radius       | `float`   | $ [0, \infty) $ | $ [0, 1] $ | $ 1                $ | Length scale of MFP
-**`subsurface_radius_scale`**       | Radius scale | `vector3` | $ [0, 1]^3    $ |            | $ (1.0, 0.5, 0.25) $ | RGB multiplier to **`subsurface_radius`**, giving the per-channel MFPs
+**`subsurface_radius_scale`**       | Radius scale | `color3`  | $ [0, 1]^3    $ |            | $ (1.0, 0.5, 0.25) $ | RGB multiplier to **`subsurface_radius`**, giving the per-channel MFPs
 **`subsurface_scatter_anisotropy`** | Anisotropy   | `float`   | $ [-1, 1]     $ |            | $ 0                $ | Anisotropy of the Henyey--Greenstein phase function of the interior medium $V^\infty_\mathrm{subsurface}$
 
 ![](images/subsurface1.jpg width=99%) ![](images/subsurface2.jpg width=99%) ![](images/subsurface3.jpg width=99%)

--- a/parametrization.md.html
+++ b/parametrization.md.html
@@ -44,7 +44,7 @@ To guarantee a non-ambiguous way to transport and present the model across diffe
 | `subsurface_weight`                   | Weight              | `float`   | $ [0, 1]        $ |               | $ 0                $ |                  |
 | `subsurface_color`                    | Color               | `color3`  | $ [0, 1]        $ |               | $ (0.8, 0.8, 0.8)  $ |                  |
 | `subsurface_radius`                   | Radius              | `float`   | $ [0, \infty)   $ | $ [0, 1]    $ | $ 1                $ | length           |
-| `subsurface_radius_scale`             | Radius scale        | `vector3` | $ [0, 1]^3      $ |               | $ (1.0, 0.5, 0.25) $ |                  |
+| `subsurface_radius_scale`             | Radius scale        | `color3`  | $ [0, 1]^3      $ |               | $ (1.0, 0.5, 0.25) $ |                  |
 | `subsurface_scatter_anisotropy`       | Anisotropy          | `float`   | $ [-1, 1]       $ |               | $ 0                $ |                  |
 | **Coat**                                                                                                                                              |
 | `coat_weight`                         | Weight              | `float`   | $ [0, 1]        $ |               | $ 0                $ |                  |

--- a/reference/open_pbr_surface.mtlx
+++ b/reference/open_pbr_surface.mtlx
@@ -177,16 +177,13 @@
     </mix>
 
     <!-- Subsurface (non-thin-walled) -->
-    <convert name="subsurface_radius_vector" type="vector3">
-      <input name="in" type="color3" interfacename="subsurface_radius_scale" />
-    </convert>
-    <multiply name="subsurface_radius_scaled" type="vector3">
-      <input name="in1" type="vector3" nodename="subsurface_radius_vector" />
+    <multiply name="subsurface_radius_scaled" type="color3">
+      <input name="in1" type="color3" interfacename="subsurface_radius_scale" />
       <input name="in2" type="float" interfacename="subsurface_radius" />
     </multiply>
     <subsurface_bsdf name="subsurface_bsdf" type="BSDF">
       <input name="color" type="color3" nodename="subsurface_color_nonnegative" />
-      <input name="radius" type="vector3" nodename="subsurface_radius_scaled" />
+      <input name="radius" type="color3" nodename="subsurface_radius_scaled" />
       <input name="anisotropy" type="float" interfacename="subsurface_scatter_anisotropy" />
       <input name="normal" type="vector3" interfacename="geometry_normal" />
     </subsurface_bsdf>


### PR DESCRIPTION
This changelist updates the types associated with physical color values for subsurface scattering in OpenPBR, aligning with the conclusions of recent threads on ASWF Slack channels.

- Change `subsurface_radius_scale` from a `vector3` to a `color3` in the specification, aligning with the MaterialX implementation of OpenPBR.
- Change the `radius` input of `subsurface_bsdf` from a `vector3` to a `color3` in the MaterialX implementation, aligning with the current definition of the `subsurface_bsdf` node in MaterialX 1.39.