### PR TITLE
Allow subsurface_radius_scale to go above 1

### DIFF
--- a/index.html
+++ b/index.html
@@ -750,7 +750,7 @@ Subsurface params                   | Label        | Type      | Range          
 **`subsurface_weight`**             | Weight       | `float`   | $ [0, 1]      $ |            | $ 0                $ | Mix weight between subsurface and diffuse slabs
 **`subsurface_color`**              | Color        | `color3`  | $ [0, 1]      $ |            | $ (0.8, 0.8, 0.8)  $ | The observed reflection color of $V^\infty_\mathrm{subsurface}$
 **`subsurface_radius`**             | Radius       | `float`   | $ [0, \infty) $ | $ [0, 1] $ | $ 1                $ | Length scale of MFP
-**`subsurface_radius_scale`**       | Radius scale | `color3`  | $ [0, 1]^3    $ |            | $ (1.0, 0.5, 0.25) $ | RGB multiplier to **`subsurface_radius`**, giving the per-channel MFPs
+**`subsurface_radius_scale`**       | Radius scale | `color3`  | $ [0, \infty)^3$| $ [0, 1]^3$| $ (1.0, 0.5, 0.25) $ | RGB multiplier to **`subsurface_radius`**, giving the per-channel MFPs
 **`subsurface_scatter_anisotropy`** | Anisotropy   | `float`   | $ [-1, 1]     $ |            | $ 0                $ | Anisotropy of the Henyey--Greenstein phase function of the interior medium $V^\infty_\mathrm{subsurface}$
 
 ![](images/subsurface1.jpg width=99%) ![](images/subsurface2.jpg width=99%) ![](images/subsurface3.jpg width=99%)

--- a/index.html
+++ b/index.html
@@ -745,13 +745,13 @@ Once the underlying volumetric medium properties $\boldsymbol{\mu}_t$, $\boldsym
 Note that the default value of **`subsurface_radius_scale`** is set at $(1, 0.5, 0.25)$ to approximate the effect of Rayleigh scattering. If we roughly approximate the wavelength corresponding to each of the RGB channels as $\lambda/\mathrm{nm} \approx 650, 550, 450$ and assume the radii scale like the reciprocal of the extinction, then since in Rayleigh scattering the extinction scales like $\lambda^{-4}$ for light of wavelength $\lambda$ the expected relative magnitudes of the radii are $(1,  (550/650)^4, (450/650)^4) \approx (1, 0.5, 0.25)$, hence the chosen default. This provides a slightly more realistic default look for the subsurface than resulting from gray radii.
 
 
-Subsurface params                   | Label        | Type      | Range           | Norm       | Default              | Description
-------------------------------------|--------------|-----------|:---------------:|:----------:|:--------------------:|----------------------------------------------
-**`subsurface_weight`**             | Weight       | `float`   | $ [0, 1]      $ |            | $ 0                $ | Mix weight between subsurface and diffuse slabs
-**`subsurface_color`**              | Color        | `color3`  | $ [0, 1]      $ |            | $ (0.8, 0.8, 0.8)  $ | The observed reflection color of $V^\infty_\mathrm{subsurface}$
-**`subsurface_radius`**             | Radius       | `float`   | $ [0, \infty) $ | $ [0, 1] $ | $ 1                $ | Length scale of MFP
-**`subsurface_radius_scale`**       | Radius scale | `color3`  | $ [0, \infty)^3$| $ [0, 1]^3$| $ (1.0, 0.5, 0.25) $ | RGB multiplier to **`subsurface_radius`**, giving the per-channel MFPs
-**`subsurface_scatter_anisotropy`** | Anisotropy   | `float`   | $ [-1, 1]     $ |            | $ 0                $ | Anisotropy of the Henyey--Greenstein phase function of the interior medium $V^\infty_\mathrm{subsurface}$
+Subsurface params                   | Label        | Type      | Range             | Norm         | Default              | Description
+------------------------------------|--------------|-----------|:-----------------:|:------------:|:--------------------:|----------------------------------------------
+**`subsurface_weight`**             | Weight       | `float`   | $ [0, 1]        $ |              | $ 0                $ | Mix weight between subsurface and diffuse slabs
+**`subsurface_color`**              | Color        | `color3`  | $ [0, 1]        $ |              | $ (0.8, 0.8, 0.8)  $ | The observed reflection color of $V^\infty_\mathrm{subsurface}$
+**`subsurface_radius`**             | Radius       | `float`   | $ [0, \infty)   $ | $ [0, 1]   $ | $ 1                $ | Length scale of MFP
+**`subsurface_radius_scale`**       | Radius scale | `color3`  | $ [0, \infty)^3 $ | $ [0, 1]^3 $ | $ (1.0, 0.5, 0.25) $ | RGB multiplier to **`subsurface_radius`**, giving the per-channel MFPs
+**`subsurface_scatter_anisotropy`** | Anisotropy   | `float`   | $ [-1, 1]       $ |              | $ 0                $ | Anisotropy of the Henyey--Greenstein phase function of the interior medium $V^\infty_\mathrm{subsurface}$
 
 ![](images/subsurface1.jpg width=99%) ![](images/subsurface2.jpg width=99%) ![](images/subsurface3.jpg width=99%)
 <div class="shifted-caption">

--- a/parametrization.md.html
+++ b/parametrization.md.html
@@ -62,7 +62,7 @@ To guarantee a non-ambiguous way to transport and present the model across diffe
 | `emission_color`                      | Color               | `color3`  | $ [0, 1]^3      $ |               | $ (1, 1, 1)        $ |                  |
 | **Thin-film**                                                                                                                                         |
 | `thin_film_weight`                    | Weight              | `float`   | $ [0, 1]        $ |               | $ 0                $ |                  |
-| `thin_film_thickness`                 | Thickness           | `float`   | $ [0, \infty)   $ | $ [0, 1] $    | $ 0.5              $ | $\mathrm{\mu m}$ |
+| `thin_film_thickness`                 | Thickness           | `float`   | $ [0, \infty)   $ | $ [0, 1]    $ | $ 0.5              $ | $\mathrm{\mu m}$ |
 | `thin_film_ior`                       | IOR                 | `float`   | $ (0, \infty)   $ | $ [1, 3]    $ | $ 1.4              $ |                  |
 | **Geometry**                                                                                                                                          |
 | `geometry_opacity`                    | Opacity             | `float`   | $ [0, 1]        $ |               | $ 1                $ |                  |

--- a/parametrization.md.html
+++ b/parametrization.md.html
@@ -44,7 +44,7 @@ To guarantee a non-ambiguous way to transport and present the model across diffe
 | `subsurface_weight`                   | Weight              | `float`   | $ [0, 1]        $ |               | $ 0                $ |                  |
 | `subsurface_color`                    | Color               | `color3`  | $ [0, 1]        $ |               | $ (0.8, 0.8, 0.8)  $ |                  |
 | `subsurface_radius`                   | Radius              | `float`   | $ [0, \infty)   $ | $ [0, 1]    $ | $ 1                $ | length           |
-| `subsurface_radius_scale`             | Radius scale        | `color3`  | $ [0, 1]^3      $ |               | $ (1.0, 0.5, 0.25) $ |                  |
+| `subsurface_radius_scale`             | Radius scale        | `color3`  | $ [0, \infty)^3 $ | $ [0, 1]^3  $ | $ (1.0, 0.5, 0.25) $ |                  |
 | `subsurface_scatter_anisotropy`       | Anisotropy          | `float`   | $ [-1, 1]       $ |               | $ 0                $ |                  |
 | **Coat**                                                                                                                                              |
 | `coat_weight`                         | Weight              | `float`   | $ [0, 1]        $ |               | $ 0                $ |                  |


### PR DESCRIPTION
This PR removes the upper bound on the supported range of values for `subsurface_radius_scale`. This lets this parameter be used to decrease the volume density, not just increase it.