### PR TITLE
Fix wrong attribute name for `geometry_thin_walled`

### DIFF
--- a/reference/open_pbr_surface.mtlx
+++ b/reference/open_pbr_surface.mtlx
@@ -769,7 +769,7 @@
       <input name="bsdf" type="BSDF" nodename="fuzz_layer" />
       <input name="edf" type="EDF" nodename="emission_edf" />
       <input name="opacity" type="float" nodename="geometry_opacity_clamped" />
-      <input name="thin_walled" type="boolean" interface="geometry_thin_walled" />
+      <input name="thin_walled" type="boolean" interfacename="geometry_thin_walled" />
     </surface>
 
     <!-- Output -->


### PR DESCRIPTION
This PR fixes the wrong attribute name in the surface construction for `geometry_thin_walled`.

Please note that the target branch is `dev_1.2`.