### PR TITLE
Fix typo in reference MaterialX graph

### DIFF
--- a/reference/open_pbr_surface.mtlx
+++ b/reference/open_pbr_surface.mtlx
@@ -665,7 +665,7 @@
       <input name="base" type="BSDF" nodename="base_substrate_attenuated" />
     </layer>
     <!-- Statistical mix of coated and uncoated base  -->
-    <mix name="partially_coated_base" type="color3">
+    <mix name="partially_coated_base" type="BSDF">
       <input name="fg" type="BSDF" nodename="coated_base_substrate" />
       <input name="bg" type="BSDF" nodename="base_substrate" />
       <input name="mix" type="float" interfacename="coat_weight" />


### PR DESCRIPTION
This changelist fixes a typo in the reference MaterialX graph for OpenPBR surface, where the return value of a BSDF mix needs to be of BSDF type.