### PR TITLE
Add Implementations section

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ OpenPBR Surface is an open standard hosted by the [Academy Software Foundation](
 * **[Reference implementation](reference/open_pbr_surface.mtlx)** – written in [MaterialX](https://materialx.org/)
 * **[BibTeX citation](openpbr.bib)**
 
+### Implementations
+
+* [Adobe OpenPBR BSDF](https://github.com/adobe/openpbr-bsdf) – Adobe's open-source BSDF implementation of OpenPBR
+
 ### Resources
 
 * [MaterialX Web Viewer](https://academysoftwarefoundation.github.io/MaterialX/?file=Materials/Examples/OpenPbr/open_pbr_default.mtlx) - WebGL rasterization renderer using MaterialX [implementation](reference/open_pbr_surface.mtlx) of OpenPBR


### PR DESCRIPTION
Adds a new **Implementations** section to the README, between the existing Specification and Resources sections.

This provides a dedicated place to reference open-source BSDF implementations of OpenPBR by the community and industry.

The first entry is [Adobe OpenPBR BSDF](https://github.com/adobe/openpbr-bsdf), Adobe's open-source BSDF implementation of OpenPBR. The repository is currently being set up and will be populated during March 2026.