### PR TITLE
Add Adobe OpenPBR BSDF reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ OpenPBR Surface is an open standard hosted by the [Academy Software Foundation](
 
 * [MaterialX Web Viewer](https://academysoftwarefoundation.github.io/MaterialX/?file=Materials/Examples/OpenPbr/open_pbr_default.mtlx) - WebGL rasterization renderer using MaterialX [implementation](reference/open_pbr_surface.mtlx) of OpenPBR
 * [OpenPBR-viewer](https://github.com/portsmouth/OpenPBR-viewer) - self-contained example implementation in a WebGL pathtracer (run [here](https://portsmouth.github.io/OpenPBR-viewer))
-* [#openpbr](https://academysoftwarefdn.slack.com/channels/openpbr) - public Slack channel for discussions, hosted by ASWF
 * [Adobe OpenPBR BSDF](https://github.com/adobe/openpbr-bsdf) – Adobe's open-source BSDF implementation of OpenPBR
+* [#openpbr](https://academysoftwarefdn.slack.com/channels/openpbr) - public Slack channel for discussions, hosted by ASWF
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ OpenPBR Surface is an open standard hosted by the [Academy Software Foundation](
 * [MaterialX Web Viewer](https://academysoftwarefoundation.github.io/MaterialX/?file=Materials/Examples/OpenPbr/open_pbr_default.mtlx) - WebGL rasterization renderer using MaterialX [implementation](reference/open_pbr_surface.mtlx) of OpenPBR
 * [OpenPBR-viewer](https://github.com/portsmouth/OpenPBR-viewer) - self-contained example implementation in a WebGL pathtracer (run [here](https://portsmouth.github.io/OpenPBR-viewer))
 * [#openpbr](https://academysoftwarefdn.slack.com/channels/openpbr) - public Slack channel for discussions, hosted by ASWF
+* [Adobe OpenPBR BSDF](https://github.com/adobe/openpbr-bsdf) – Adobe's open-source BSDF implementation of OpenPBR
 
 <br/>
 


### PR DESCRIPTION
Add Adobe OpenPBR BSDF to the Resources section in README. This links to Adobe's open-source BSDF implementation of OpenPBR.