### PR TITLE
Fix 1.1.1: metal edge tint weight and thin-walled geometry flag

### DIFF
--- a/reference/open_pbr_surface.mtlx
+++ b/reference/open_pbr_surface.mtlx
@@ -77,7 +77,7 @@
            doc="The color of the emitted light." />
     <input name="geometry_opacity" type="float" value="1" uimin="0" uimax="1" uiname="Opacity" uifolder="Geometry" hint="opacity"
            doc="The opacity of the entire material." />
-    <input name="geometry_thin_walled" type="boolean" value="false" uiname="Thin Walled" uifolder="Geometry" uiadvanced="true"
+    <input name="geometry_thin_walled" type="boolean" value="false" uniform="true" uiname="Thin Walled" uifolder="Geometry" uiadvanced="true"
            doc="If true the surface is double-sided and represents an infinitesimally thin shell. Suitable for extremely geometrically thin objects such as leaves or paper." />
     <input name="geometry_normal" type="vector3" defaultgeomprop="Nworld" uiname="Normal" uifolder="Geometry"
            doc="Input geometric normal" />
@@ -615,6 +615,7 @@
       <input name="bsdf" type="BSDF" nodename="fuzz_layer" />
       <input name="edf" type="EDF" nodename="emission_edf" />
       <input name="opacity" type="float" interfacename="geometry_opacity" />
+      <input name="thin_walled" type="boolean" interfacename="geometry_thin_walled" />
     </surface>
 
     <!-- Output -->

--- a/reference/open_pbr_surface.mtlx
+++ b/reference/open_pbr_surface.mtlx
@@ -424,14 +424,10 @@
       <input name="in1" type="color3" interfacename="base_color" />
       <input name="in2" type="float" interfacename="base_weight" />
     </multiply>
-    <multiply name="metal_edgecolor" type="color3">
-      <input name="in1" type="color3" interfacename="specular_color" />
-      <input name="in2" type="float" interfacename="specular_weight" />
-    </multiply>
     <generalized_schlick_bsdf name="metal_bsdf" type="BSDF">
       <input name="weight" type="float" interfacename="specular_weight" />
       <input name="color0" type="color3" nodename="metal_reflectivity" />
-      <input name="color82" type="color3" nodename="metal_edgecolor" />
+      <input name="color82" type="color3" interfacename="specular_color" />
       <input name="roughness" type="vector2" nodename="main_roughness" />
       <input name="normal" type="vector3" interfacename="geometry_normal" />
       <input name="tangent" type="vector3" interfacename="geometry_tangent" />
@@ -439,7 +435,7 @@
     <generalized_schlick_bsdf name="metal_bsdf_tf" type="BSDF">
       <input name="weight" type="float" interfacename="specular_weight" />
       <input name="color0" type="color3" nodename="metal_reflectivity" />
-      <input name="color82" type="color3" nodename="metal_edgecolor" />
+      <input name="color82" type="color3" interfacename="specular_color" />
       <input name="roughness" type="vector2" nodename="main_roughness" />
       <input name="normal" type="vector3" interfacename="geometry_normal" />
       <input name="tangent" type="vector3" interfacename="geometry_tangent" />


### PR DESCRIPTION
Two bug fixes for the 1.1.1 point release:

- Metal edge tint incorrectly multiplied by specular_weight (cherry-picked from AcademySoftwareFoundation/OpenPBR#240): the color82 (edge tint) input on metal_bsdf and metal_bsdf_tf was routed through a multiply node that applied specular_weight. Since the whole lobe is already weighted by specular_weight, the edge tint was being double-weighted. Now connects directly to the specular_color interface input.

- Connect geometry_thin_walled flag to <surface> (borrowed from AcademySoftwareFoundation/MaterialX#2759): the thin-walled geometry flag was not being passed through to the surface node in the MaterialX graph.